### PR TITLE
Add error bar plots

### DIFF
--- a/examples/fig5_errorbar.nim
+++ b/examples/fig5_errorbar.nim
@@ -15,11 +15,25 @@ d.marker = Marker[float](size: size, color: colors)
 d.xs = @[1'f64, 2, 3, 4, 5]
 d.ys = @[1'f64, 2, 1, 9, 5]
 
-# set an asymmetric error bar on x
-d.xs_err = newErrorBar((0.2, 0.5), color = colors[0])
+# example of constant error
+# d.xs_err = newErrorBar(0.5, color = colors[0])
+# example of constant percentual error. Note that the value given is in actual
+# percent and not a ratio
+# d.xs_err = newErrorBar(10.0, color = colors[0], percent = true)
+# example of an asymmetric error bar on x
+d.xs_err = newErrorBar((0.1, 0.25), color = colors[0])
+
 # create a sequence of increasing error bars for y
-let yerrs = @[0.1, 0.2, 0.3, 0.4, 0.5]
+let yerrs = mapIt(toSeq(0..5), it.float * 0.25)
 d.ys_err = newErrorBar(yerrs, color = colors[0])
+# import algorithm
+# example of asymmetric error bars for each element
+# let yerrs_high = @[0.1, 0.2, 0.3, 0.4, 0.5].reversed
+# d.ys_err = newErrorBar((yerrs_low, yerrs_high), color = colors[0])
+# example of a sqrt error on y. Need to hand the correct type here manually,
+# otherwise we'll get a "cannot instantiate `ErrorBar[T]`" error, due to
+# no value from which type can be deduced is present
+# d.ys_err = newErrorBar[float](color = colors[0])
 
 d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
 

--- a/examples/fig5_errorbar.nim
+++ b/examples/fig5_errorbar.nim
@@ -1,0 +1,29 @@
+import sequtils
+import plotly
+import chroma
+
+# simple example showcasing scatter plot with error bars
+
+var colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
+               Color(r:0.9, g:0.4, b:0.2, a: 1.0),
+               Color(r:0.2, g:0.9, b:0.2, a: 1.0),
+               Color(r:0.1, g:0.7, b:0.1, a: 1.0),
+               Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
+var d = Trace[float](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
+var size = @[16.float]
+d.marker = Marker[float](size: size, color: colors)
+d.xs = @[1'f64, 2, 3, 4, 5]
+d.ys = @[1'f64, 2, 1, 9, 5]
+
+# set an asymmetric error bar on x
+d.xs_err = newErrorBar((0.2, 0.5), color = colors[0])
+# create a sequence of increasing error bars for y
+let yerrs = @[0.1, 0.2, 0.3, 0.4, 0.5]
+d.ys_err = newErrorBar(yerrs, color = colors[0])
+
+d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
+
+var layout = Layout(title: "testing", width: 1200, height: 400, xaxis: Axis(title:"my x-axis"), yaxis:Axis(title: "y-axis too"), autosize:false)
+var p = Plot[float](layout:layout, datas: @[d])
+echo p.save()
+p.show()

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -1,9 +1,17 @@
-include plotly/api
-import plotly/browser
 import os
 import strutils
 import json
 import chroma
+
+# we now import the plotly modules and export them so that
+# the user sees them as a single module
+import plotly/api
+export api
+import plotly/plotly_types
+export plotly_types
+import plotly/errorbar
+export errorbar
+import plotly/browser
 
 type
   Plot*[T:SomeNumber] = ref object
@@ -70,7 +78,7 @@ when isMainModule:
 
     var n = 70
     var color_choice = @[Color(r:0.9, g:0.1, b:0.1, a:1.0), Color(r:0.1, g:0.1, b:0.9, a:1.0)]
-  
+
     var
       y = new_seq[float64](n)
       x = new_seq[float64](n)
@@ -91,12 +99,12 @@ when isMainModule:
 
     var d = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, xs:x, ys:y, text:text)
     d.marker = Marker[float64](size:sizes, color:colors)
-  
+
     var layout = Layout(title: "saw the sin", width: 1200, height: 400,
                         xaxis: Axis(title:"my x-axis"),
                         yaxis:Axis(title: "y-axis too"), autosize:false)
     Plot[float64](layout:layout, datas: @[d]).show()
-  
+
   block:
     var text = @["a", "b", "c", "d"]
     var layout = Layout(title: "nim-plotly bar+scattter chart example", width: 1200, height: 400,
@@ -137,7 +145,3 @@ when isMainModule:
                         yaxis2: Axis(title:"cos", side:PlotSide.Right), autosize:false)
 
     Plot[float64](layout:layout, datas: @[t1, t2]).show()
-
-    
-
-

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -43,7 +43,10 @@ type
     of ebkPercentAsym:
       percentMinus*: T
       percentPlus*: T
-    of ebkSqrt: discard
+    of ebkSqrt:
+      # NOTE: the fact that we technically have not type T in the `ErrorBar` for
+      # this variant means we have to hand it to the `newErrorBar` proc manually!
+      discard
     of ebkArraySym:
       errors*: seq[T]
     of ebkArrayAsym:
@@ -101,10 +104,12 @@ func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 
                          width: width, kind: ebkPercentSym)
     result.percent = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[p, m: T], color: Color, thickness = 0.0,
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: T], color: Color, thickness = 0.0,
                                  width = 0.0, visible = true, percent = false): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkConstantAsym`, constant plus and
   ## minus errors given as tuple or `ebkPercentAsym` of `percent` flag is set to true
+  ## Note: the first element of the `err` tuple is the `negative` size, the second
+  ## the positive!
   if percent == false:
     result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
                          width: width, kind: ebkConstantAsym)
@@ -129,9 +134,11 @@ func newErrorBar*[T](err: seq[T], color: Color, thickness = 0.0, width = 0.0,
                        width: width, kind: ebkArraySym)
   result.errors = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[p, m: seq[T]], color: Color,
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: seq[T]], color: Color,
                                  thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkArrayAsym`, where the first
+  ## Note: the first seq of the `err` tuple is the `negative` error seq, the second
+  ## the positive!
   result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
                        width: width, kind: ebkArrayAsym)
   result.errorsPlus  = err.p

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -87,41 +87,53 @@ type
     yaxis*: Axis
     yaxis2*: Axis
 
-func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 0.0, visible = true, percent = false): ErrorBar[T] =
+func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 0.0,
+                                 visible = true, percent = false): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkConstantSym` or `ebkPercentSym`, if the `percent` flag
   ## is set to `true`
   # NOTE: there is a lot of visual noise in the creation here... change how?
   if percent == false:
-    result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkConstantSym)
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkConstantSym)
     result.value = err
   else:
-    result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkPercentSym)
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkPercentSym)
     result.percent = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[p, m: T], color: Color, thickness = 0.0, width = 0.0, visible = true, percent = false): ErrorBar[T] =
-  ## creates an `ErrorBar` object of type `ebkConstantAsym`, constant plus and minus errors given as tuple
-  ## or `ebkPercentAsym` of `percent` flag is set to true
+func newErrorBar*[T: SomeNumber](err: tuple[p, m: T], color: Color, thickness = 0.0,
+                                 width = 0.0, visible = true, percent = false): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkConstantAsym`, constant plus and
+  ## minus errors given as tuple or `ebkPercentAsym` of `percent` flag is set to true
   if percent == false:
-    result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkConstantAsym)
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkConstantAsym)
     result.valuePlus  = err.p
     result.valueMinus = err.m
   else:
-    result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkPercentAsym)
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkPercentAsym)
     result.percentPlus  = err.p
     result.percentMinus = err.m
 
-func newErrorBar*[T: SomeNumber](color: Color, thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
+func newErrorBar*[T: SomeNumber](color: Color, thickness = 0.0, width = 0.0,
+                                 visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkSqrt`
-  result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkSqrt)
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkSqrt)
 
-func newErrorBar*[T](err: seq[T], color: Color, thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
+func newErrorBar*[T](err: seq[T], color: Color, thickness = 0.0, width = 0.0,
+                     visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkArraySym`
-  result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkArraySym)
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                       width: width, kind: ebkArraySym)
   result.errors = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[p, m: seq[T]], color: Color, thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
-  ## creates an `ErrorBar` object of type `ebkArrayAsym`
-  result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkArraySym)
+func newErrorBar*[T: SomeNumber](err: tuple[p, m: seq[T]], color: Color,
+                                 thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkArrayAsym`, where the first
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                       width: width, kind: ebkArrayAsym)
   result.errorsPlus  = err.p
   result.errorsMinus = err.m
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -18,7 +18,7 @@ type
     Left = "left"
     Right = "right"
 
-  ErrorBarKind = enum   # different error bar kinds (from constant value, array,...)
+  ErrorBarKind* = enum   # different error bar kinds (from constant value, array,...)
     ebkConstantSym,      # constant symmetric error
     ebkConstantAsym,     # constant asymmetric error
     ebkPercentSym,       # symmetric error on percent of value

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -57,7 +57,6 @@ type
   Trace*[T: SomeNumber] = ref object
     xs*: seq[T]
     ys*: seq[T]
-    # TODO: allow for single element errors or use single element seqs for that?
     xs_err*: ErrorBar[T]
     ys_err*: ErrorBar[T]
     marker*: Marker[T]
@@ -91,6 +90,7 @@ type
 func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 0.0, visible = true, percent = false): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkConstantSym` or `ebkPercentSym`, if the `percent` flag
   ## is set to `true`
+  # NOTE: there is a lot of visual noise in the creation here... change how?
   if percent == false:
     result = ErrorBar[T](visible: visible, color: color, thickness: thickness, width: width, kind: ebkConstantSym)
     result.value = err

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -286,4 +286,5 @@ func json*(d: Trace, as_pretty=true): string =
   var j = % d
   if as_pretty:
     result = pretty(j)
-  result = $d
+  else:
+    result = $d

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -3,7 +3,6 @@ import json
 import chroma
 
 type
-
   PlotType* {.pure.} = enum
     Scatter = "scatter"
     ScatterGL = "scattergl"
@@ -54,14 +53,14 @@ type
     yaxis*: Axis
     yaxis2*: Axis
 
-proc empty(c:Color): bool =
+func empty(c: Color): bool =
   # TODO: this is also black, but should never need black with alpha == 0
-  return c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0
+  result = c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0
 
-proc `%`*(c:Color): string =
-  return c.toHtmlHex()
+func `%`*(c: Color): string =
+  result = c.toHtmlHex()
 
-proc `%`*(f:Font): JsonNode =
+func `%`*(f: Font): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if f.size != 0:
     fields["size"] = % f.size
@@ -71,7 +70,7 @@ proc `%`*(f:Font): JsonNode =
     fields["family"] = % f.family
   result = JsonNode(kind:Jobject, fields:  fields)
 
-proc `%`*(a:Axis): JsonNode =
+func `%`*(a: Axis): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if a.title != nil and a.title != "":
     fields["title"] = % a.title
@@ -85,7 +84,7 @@ proc `%`*(a:Axis): JsonNode =
 
   result = JsonNode(kind:Jobject, fields:  fields)
 
-proc `%`*(l:Layout): JsonNode =
+func `%`*(l: Layout): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if l.title != "":
     fields["title"] = % l.title
@@ -102,12 +101,13 @@ proc `%`*(l:Layout): JsonNode =
 
   result = JsonNode(kind:Jobject, fields:  fields)
 
-proc toHtmlHex(colors: seq[Color]): seq[string] =
+func toHtmlHex(colors: seq[Color]): seq[string] =
   result = new_seq[string](len(colors))
   for i, c in colors:
     result[i] = c.toHtmlHex
 
 proc `%`*(t: Trace): JsonNode =
+func `%`*(t: Trace): JsonNode =
   var fields = initOrderedTable[string, JsonNode](8)
   if t.xs == nil or t.xs.len == 0:
     if t.text != nil:
@@ -127,7 +127,7 @@ proc `%`*(t: Trace): JsonNode =
     fields["marker"] = % t.marker
   result = JsonNode(kind:Jobject, fields:  fields)
 
-proc `%`*(m: Marker): JsonNode =
+func `%`*(m: Marker): JsonNode =
   var fields = initOrderedTable[string, JsonNode](8)
   if m.size != nil:
     if m.size.len == 1:
@@ -141,12 +141,12 @@ proc `%`*(m: Marker): JsonNode =
       fields["color"] = % m.color.toHtmlHex()
   result = JsonNode(kind:Jobject, fields:  fields)
 
-proc `$`*(d:Trace): string =
+func `$`*(d: Trace): string =
   var j = % d
-  return $j
+  result = $j
 
-proc json*(d:Trace, as_pretty=true): string =
+func json*(d: Trace, as_pretty=true): string =
   var j = % d
   if as_pretty:
-    return pretty(j)
-  return $d
+    result = pretty(j)
+  result = $d

--- a/src/plotly/color.nim
+++ b/src/plotly/color.nim
@@ -1,0 +1,13 @@
+import chroma
+
+# this module contains utility functions used in other modules of plotly
+# related to the chroma module
+
+func empty*(c: Color): bool =
+  # TODO: this is also black, but should never need black with alpha == 0
+  result = c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0
+
+func toHtmlHex*(colors: seq[Color]): seq[string] =
+  result = new_seq[string](len(colors))
+  for i, c in colors:
+    result[i] = c.toHtmlHex

--- a/src/plotly/errorbar.nim
+++ b/src/plotly/errorbar.nim
@@ -1,0 +1,61 @@
+import chroma
+
+# plotly internal modules
+import plotly_types
+
+# this module contains all procedures related to the `ErrorBar` class
+# e.g. convenience functions to create a new `ErrorBar` object
+
+func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 0.0,
+                                 visible = true, percent = false): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkConstantSym` or `ebkPercentSym`, if the `percent` flag
+  ## is set to `true`
+  # NOTE: there is a lot of visual noise in the creation here... change how?
+  if percent == false:
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkConstantSym)
+    result.value = err
+  else:
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkPercentSym)
+    result.percent = err
+
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: T], color: Color, thickness = 0.0,
+                                 width = 0.0, visible = true, percent = false): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkConstantAsym`, constant plus and
+  ## minus errors given as tuple or `ebkPercentAsym` of `percent` flag is set to true
+  ## Note: the first element of the `err` tuple is the `negative` size, the second
+  ## the positive!
+  if percent == false:
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkConstantAsym)
+    result.valuePlus  = err.p
+    result.valueMinus = err.m
+  else:
+    result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkPercentAsym)
+    result.percentPlus  = err.p
+    result.percentMinus = err.m
+
+func newErrorBar*[T: SomeNumber](color: Color, thickness = 0.0, width = 0.0,
+                                 visible = true): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkSqrt`
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                         width: width, kind: ebkSqrt)
+
+func newErrorBar*[T](err: seq[T], color: Color, thickness = 0.0, width = 0.0,
+                     visible = true): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkArraySym`
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                       width: width, kind: ebkArraySym)
+  result.errors = err
+
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: seq[T]], color: Color,
+                                 thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
+  ## creates an `ErrorBar` object of type `ebkArrayAsym`, where the first
+  ## Note: the first seq of the `err` tuple is the `negative` error seq, the second
+  ## the positive!
+  result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
+                       width: width, kind: ebkArrayAsym)
+  result.errorsPlus  = err.p
+  result.errorsMinus = err.m

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -1,0 +1,91 @@
+import chroma
+
+# this module contains all types used in the plotly module
+
+type
+  PlotType* {.pure.} = enum
+    Scatter = "scatter"
+    ScatterGL = "scattergl"
+    Bar = "bar"
+
+  PlotMode* {.pure.} = enum
+    Lines = "lines"
+    Markers = "markers"
+    LinesMarkers = "lines+markers"
+
+  PlotSide* {.pure.} = enum
+    Unset = ""
+    Left = "left"
+    Right = "right"
+
+  ErrorBarKind* = enum   # different error bar kinds (from constant value, array,...)
+    ebkConstantSym,      # constant symmetric error
+    ebkConstantAsym,     # constant asymmetric error
+    ebkPercentSym,       # symmetric error on percent of value
+    ebkPercentAsym,      # asymmetric error on percent of value
+    ebkSqrt,             # error based on sqrt of value
+    ebkArraySym,         # symmetric error based on array of length data.len
+    ebkArrayAsym        # assymmetric error based on array of length data.len
+
+  ErrorBar*[T: SomeNumber] = ref object
+    visible*: bool
+    color*: Color            # color of bars (including alpha channel)
+    thickness*: float        # thickness of bar
+    width*: float            # width of bar
+    case kind*: ErrorBarKind
+    of ebkConstantSym:
+      value*: T
+    of ebkConstantAsym:
+      valueMinus*: T
+      valuePlus*: T
+    of ebkPercentSym:
+      percent*: T
+    of ebkPercentAsym:
+      percentMinus*: T
+      percentPlus*: T
+    of ebkSqrt:
+      # NOTE: the fact that we technically have not type T in the `ErrorBar` for
+      # this variant means we have to hand it to the `newErrorBar` proc manually!
+      discard
+    of ebkArraySym:
+      errors*: seq[T]
+    of ebkArrayAsym:
+      errorsMinus*: seq[T]
+      errorsPlus*: seq[T]
+
+  Marker*[T: SomeNumber] = ref object
+    size*: seq[T]
+    color*: seq[Color]
+
+  Trace*[T: SomeNumber] = ref object
+    xs*: seq[T]
+    ys*: seq[T]
+    xs_err*: ErrorBar[T]
+    ys_err*: ErrorBar[T]
+    marker*: Marker[T]
+    text*: seq[string]
+    mode*: PlotMode
+    `type`*: PlotType
+    name*: string
+    yaxis*: string
+
+  Font* = ref object
+    family*: string
+    size*: int
+    color*: Color
+
+  Axis* = ref object
+    title*: string
+    font*: Font
+    domain*: seq[float64]
+    side*: PlotSide
+
+  Layout* = ref object
+    title*: string
+    width*: int
+    height*: int
+    autosize*: bool
+    showlegend*: bool
+    xaxis*: Axis
+    yaxis*: Axis
+    yaxis2*: Axis


### PR DESCRIPTION
First of all thanks for the great work so far!

I went ahead and added support for error bars on plots by introducing an `ErrorBar` type and `xs_err` / `ys_err` fields to the `Trace`.

I'm not sure if I'm super happy with my implementation here, but it seems to work just fine. It supports the whole range of plotly.js error bars, namely:
- constant symmetric / asymmetric
- percent symm. / asym.
- sqrt
- arrays sym / asym.

A simple example based on the scatter plot is also added.

What this PR also includes (I can cherry pick the error bar stuff out, if you don't like this):
I changed a few procs to use the `result` variable instead of return, changed the style of the whitespace for the argument type and replaced the `proc` keyword with the new `func` keyword in `api.nim`. 
