### PR TITLE
make code more Nim idiomatic

### DIFF
--- a/examples/fig1_simple_scatter.nim
+++ b/examples/fig1_simple_scatter.nim
@@ -1,20 +1,24 @@
 import plotly
 import chroma
 
-var colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
-               Color(r:0.9, g:0.4, b:0.2, a: 1.0),
-               Color(r:0.2, g:0.9, b:0.2, a: 1.0),
-               Color(r:0.1, g:0.7, b:0.1, a: 1.0),
-               Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
-var d = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
-var size = @[16.int]
-d.marker = Marker[int](size:size, color: colors)
+const colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
+                 Color(r:0.9, g:0.4, b:0.2, a: 1.0),
+                 Color(r:0.2, g:0.9, b:0.2, a: 1.0),
+                 Color(r:0.1, g:0.7, b:0.1, a: 1.0),
+                 Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
+let
+  d = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
+  size = @[16.int]
+d.marker = Marker[int](size: size, color: colors)
 d.xs = @[1, 2, 3, 4, 5]
 d.ys = @[1, 2, 1, 9, 5]
 d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
 
-var layout = Layout(title: "testing", width: 1200, height: 400, xaxis: Axis(title:"my x-axis"), yaxis:Axis(title: "y-axis too"), autosize:false)
-#echo $(%layout)
-var p = Plot[int](layout:layout, datas: @[d])
+let
+  layout = Layout(title: "testing", width: 1200, height: 400,
+                  xaxis: Axis(title:"my x-axis"),
+                  yaxis: Axis(title: "y-axis too"),
+                  autosize: false)
+  p = Plot[int](layout: layout, datas: @[d])
 echo p.save()
 p.show()

--- a/examples/fig2_scatter_colors_sizes.nim
+++ b/examples/fig2_scatter_colors_sizes.nim
@@ -2,8 +2,10 @@ import plotly
 import math
 import chroma
 
-var n = 70
-var color_choice = @[Color(r:0.9, g:0.1, b:0.1, a:1.0), Color(r:0.1, g:0.1, b:0.9, a:1.0)]
+const
+  n = 70
+  color_choice = @[Color(r: 0.9, g: 0.1, b: 0.1, a: 1.0),
+                   Color(r: 0.1, g: 0.1, b: 0.9, a: 1.0)]
 
 var
   y = new_seq[float64](n)
@@ -12,7 +14,7 @@ var
   colors = new_seq[Color](n)
   sizes = new_seq[float64](n)
 
-for i in 0..y.high:
+for i in 0 .. y.high:
   x[i] = i.float
   y[i] = sin(i.float)
   text[i] = $i & " has the sin value: " & $y[i]
@@ -23,10 +25,11 @@ for i in 0..y.high:
     colors[i] = color_choice[1]
   text[i] = text[i] & "<b>" & colors[i].toHtmlHex() & "</b>"
 
-var d = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, xs:x, ys:y, text:text)
-d.marker = Marker[float64](size:sizes, color:colors)
+let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                       xs: x, ys: y, text: text)
+d.marker = Marker[float64](size: sizes, color: colors)
 
-var layout = Layout(title: "saw the sin", width: 1200, height: 400,
-                    xaxis: Axis(title:"my x-axis"),
-                    yaxis:Axis(title: "y-axis too"), autosize:false)
-Plot[float64](layout:layout, datas: @[d]).show()
+let layout = Layout(title: "saw the sin", width: 1200, height: 400,
+                    xaxis: Axis(title: "my x-axis"),
+                    yaxis: Axis(title: "y-axis too"), autosize: false)
+Plot[float64](layout: layout, datas: @[d]).show()

--- a/examples/fig3_multiple_plot_types.nim
+++ b/examples/fig3_multiple_plot_types.nim
@@ -1,21 +1,28 @@
 import plotly
 import chroma
 
-var text = @["a", "b", "c", "d"]
-var layout = Layout(title: "nim-plotly bar+scattter chart example", width: 1200, height: 400,
-                    xaxis: Axis(title:"category"),
-                    yaxis: Axis(title:"value"), autosize:false)
+const
+  text = @["a", "b", "c", "d"]
+  # some data
+  y = @[25.5'f64, 5, 9, 10.0]
+  y2 = @[35.5'f64, 1, 19, 20.0]
+  y3 = @[15.5'f64, 41, 29, 30.0]
 
-var y = @[25.5'f64, 5, 9, 10.0]
-var y2 = @[35.5'f64, 1, 19, 20.0]
-var y3 = @[15.5'f64, 41, 29, 30.0]
-
-var d1 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y, text:text, name: "first group")
-var d2 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y2, text:text, name: "second group")
-var d3 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y3, text:text, name: "third group")
-var d4 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, ys:y3, text:text, name: "scatter")
-var d5 = Trace[float64](mode:PlotMode.Markers, `type`: PlotType.ScatterGL, ys:y, text:text, name: "just markers")
+let
+  layout = Layout(title: "nim-plotly bar+scattter chart example", width: 1200, height: 400,
+                  xaxis: Axis(title: "category"),
+                  yaxis: Axis(title: "value"), autosize: false)
+  # some `Trace` instances
+  d1 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y,
+                      text: text, name: "first group")
+  d2 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y2,
+                      text: text, name: "second group")
+  d3 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y3,
+                      text: text, name: "third group")
+  d4 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, ys: y3,
+                      text: text, name: "scatter")
+  d5 = Trace[float64](mode: PlotMode.Markers, `type`: PlotType.ScatterGL, ys: y,
+                      text: text, name: "just markers")
 d5.marker = Marker[float64](size: @[25'f64])
 
 Plot[float64](layout:layout, datas: @[d1, d2, d3, d4, d5]).show()
-

--- a/examples/fig4_multiple_axes.nim
+++ b/examples/fig4_multiple_axes.nim
@@ -2,24 +2,24 @@ import math
 import plotly
 
 const n = 50
-var y1 = new_seq[float64](n)
-var y2 = new_seq[float64](n)
-var x = new_seq[float64](n)
+var
+  y1 = newSeq[float64](n)
+  y2 = newSeq[float64](n)
+  x  = newSeq[float64](n)
 
-for i in 0..x.high:
+for i in 0 .. x.high:
   x[i] = i.float64
   y1[i] = sin(i.float64) * 100
   y2[i] = cos(i.float64) / 100
 
-var t1 = Trace[float64](mode:PlotMode.Lines, `type`: PlotType.Scatter, ys:y1, name: "sin*100")
-var t2 = Trace[float64](mode:PlotMode.Lines, `type`: PlotType.Scatter, ys:y2, name: "cos/100", yaxis:"y2")
-var layout = Layout(title: "multiple axes in nim plotly", width: 1200, height: 400,
-                    xaxis: Axis(title:"x"),
-                    yaxis: Axis(title:"sin"),
-                    yaxis2: Axis(title:"cos", side:PlotSide.Right), autosize:false)
+let
+  t1 = Trace[float64](mode: PlotMode.Lines, `type`: PlotType.Scatter, ys: y1,
+                      name: "sin*100")
+  t2 = Trace[float64](mode: PlotMode.Lines, `type`: PlotType.Scatter, ys: y2,
+                      name: "cos/100", yaxis: "y2")
+  layout = Layout(title: "multiple axes in nim plotly", width: 1200, height: 400,
+                  xaxis: Axis(title: "x"),
+                  yaxis: Axis(title: "sin"),
+                  yaxis2: Axis(title: "cos", side: PlotSide.Right), autosize: false)
 
 Plot[float64](layout:layout, datas: @[t1, t2]).show()
-
-    
-
-

--- a/examples/fig5_errorbar.nim
+++ b/examples/fig5_errorbar.nim
@@ -4,13 +4,14 @@ import chroma
 
 # simple example showcasing scatter plot with error bars
 
-var colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
-               Color(r:0.9, g:0.4, b:0.2, a: 1.0),
-               Color(r:0.2, g:0.9, b:0.2, a: 1.0),
-               Color(r:0.1, g:0.7, b:0.1, a: 1.0),
-               Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
-var d = Trace[float](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
-var size = @[16.float]
+const colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
+                 Color(r:0.9, g:0.4, b:0.2, a: 1.0),
+                 Color(r:0.2, g:0.9, b:0.2, a: 1.0),
+                 Color(r:0.1, g:0.7, b:0.1, a: 1.0),
+                 Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
+let
+  d = Trace[float](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
+  size = @[16.float]
 d.marker = Marker[float](size: size, color: colors)
 d.xs = @[1'f64, 2, 3, 4, 5]
 d.ys = @[1'f64, 2, 1, 9, 5]
@@ -37,7 +38,10 @@ d.ys_err = newErrorBar(yerrs, color = colors[0])
 
 d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
 
-var layout = Layout(title: "testing", width: 1200, height: 400, xaxis: Axis(title:"my x-axis"), yaxis:Axis(title: "y-axis too"), autosize:false)
-var p = Plot[float](layout:layout, datas: @[d])
+let
+  layout = Layout(title: "testing", width: 1200, height: 400,
+                  xaxis: Axis(title: "my x-axis"),
+                  yaxis: Axis(title: "y-axis too"), autosize: false)
+  p = Plot[float](layout: layout, datas: @[d])
 echo p.save()
 p.show()

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -2,6 +2,7 @@ import os
 import strutils
 import json
 import chroma
+import sequtils
 
 # we now import the plotly modules and export them so that
 # the user sees them as a single module
@@ -18,75 +19,89 @@ type
     datas* : seq[Trace[T]]
     layout*: Layout
 
-proc newPlot*(xlabel:string="", ylabel:string="", title:string=""): Plot[float64] =
+const defaultTmplPath = currentSourcePath().parentDir / "tmpl.html"
+
+proc newPlot*(xlabel = "", ylabel = "", title = ""): Plot[float64] =
   ## create a plot with sane default layout.
   result = Plot[float64]()
-  result.datas = new_seq[Trace[float64]]()
-  result.layout = Layout(title: title, width: 600, height: 600, xaxis: Axis(title:xlabel), yaxis:Axis(title: ylabel), autosize:false)
+  result.datas = newSeq[Trace[float64]]()
+  result.layout = Layout(title: title, width: 600, height: 600,
+                         xaxis: Axis(title: xlabel),
+                         yaxis: Axis(title: ylabel),
+                         autosize: false)
 
-proc add*[T](p:Plot, d:Trace[T]) =
+proc add*[T](p: Plot, d: Trace[T]) =
   ## add a new data set to a plot.
   if p.datas == nil:
-    p.datas = new_seq[Trace[float64]]()
+    p.datas = newSeq[Trace[float64]]()
   p.datas.add(d)
 
-proc show*(p:Plot, path:string="", html_template:string=currentSourcePath().parentDir / "tmpl.html") =
-  var path = p.save(path, html_template)
+proc show*(p: Plot, path = "", html_template = defaultTmplPath) =
+  let path = p.save(path, html_template)
   browser.open(path)
   removeFile(path)
 
-proc save*(p:Plot, path:string="", html_template:string=currentSourcePath().parentDir / "tmpl.html"): string =
-  var ipath = path
-  if ipath == "":
-    ipath = "/tmp/x.html"
-  var jsons = new_seq[string]()
-  for d in p.datas:
-    jsons.add(d.json(as_pretty=true))
-  var data_string = "[" & join(jsons, ",") & "]"
-  var s = ($readFile(html_template)) % ["data", data_string, "layout", $(%p.layout), "title", p.layout.title]
-  var f:File
-  if not open(f, ipath, fmWrite):
+proc save*(p: Plot, path = "", html_template = defaultTmplPath): string =
+  result = path
+  if result == "":
+    result = "/tmp/x.html"
+  let
+    # call `json` for each element of `Plot.datas`
+    jsons = mapIt(p.datas, it.json(as_pretty = true))
+    data_string = "[" & join(jsons, ",") & "]"
+    # read the HTML template and insert data, layout and title strings
+    s = ($readFile(html_template)) % ["data", data_string, "layout", $(%p.layout),
+                                      "title", p.layout.title]
+  var
+    f: File
+  if not open(f, result, fmWrite):
     quit "could not open file for json"
   f.write(s)
   f.close()
-  return ipath
 
 when isMainModule:
   import math
 
-  var colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
-                 Color(r:0.9, g:0.4, b:0.2, a: 1.0),
-                 Color(r:0.2, g:0.9, b:0.2, a: 1.0),
-                 Color(r:0.1, g:0.7, b:0.1, a: 1.0),
-                 Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
-  var d = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
-  var size = @[16.int]
-  var m = Marker[int](size:size, color: colors)
+  let
+    # define a few colors
+    colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
+               Color(r:0.9, g:0.4, b:0.2, a: 1.0),
+               Color(r:0.2, g:0.9, b:0.2, a: 1.0),
+               Color(r:0.1, g:0.7, b:0.1, a: 1.0),
+               Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
+    d = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
+    size = @[16.int]
+    m = Marker[int](size: size, color: colors)
+  # assign fields of `Trace` object
   d.marker = m
   d.xs = @[1, 2, 3, 4, 5]
   d.ys = @[1, 2, 1, 9, 5]
   d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
 
-  var layout = Layout(title: "testing", width: 1200, height: 400, xaxis: Axis(title:"my x-axis"), yaxis:Axis(title: "y-axis too"), autosize:false)
-  #echo $(%layout)
-  var p = Plot[int](layout:layout, datas: @[d])
+  let
+    layout = Layout(title: "testing", width: 1200, height: 400,
+                    xaxis: Axis(title:"my x-axis"),
+                    yaxis:Axis(title: "y-axis too"),
+                    autosize:false)
+    p = Plot[int](layout: layout, datas: @[d])
   echo p.save()
   p.show()
 
-
   block:
 
-    var n = 70
-    var color_choice = @[Color(r:0.9, g:0.1, b:0.1, a:1.0), Color(r:0.1, g:0.1, b:0.9, a:1.0)]
+    const
+      n = 70
+      color_choice = @[Color(r: 0.9, g: 0.1, b: 0.1, a: 1.0),
+                       Color(r: 0.1, g: 0.1, b: 0.9, a: 1.0)]
 
     var
-      y = new_seq[float64](n)
-      x = new_seq[float64](n)
-      text = new_seq[string](n)
-      colors = new_seq[Color](n)
-      sizes = new_seq[float64](n)
+      y = newSeq[float64](n)
+      x = newSeq[float64](n)
+      text = newSeq[string](n)
+      colors = newSeq[Color](n)
+      sizes = newSeq[float64](n)
 
-    for i in 0..y.high:
+    for i in 0 .. y.high:
       x[i] = i.float
       y[i] = sin(i.float)
       text[i] = $i & " has the sin value: " & $y[i]
@@ -97,51 +112,62 @@ when isMainModule:
         colors[i] = color_choice[1]
       text[i] = text[i] & "<b>" & colors[i].toHtmlHex() & "</b>"
 
-    var d = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, xs:x, ys:y, text:text)
-    d.marker = Marker[float64](size:sizes, color:colors)
+    let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                           xs: x, ys: y, text: text)
+    d.marker = Marker[float64](size: sizes, color: colors)
 
-    var layout = Layout(title: "saw the sin", width: 1200, height: 400,
+    let layout = Layout(title: "saw the sin", width: 1200, height: 400,
                         xaxis: Axis(title:"my x-axis"),
-                        yaxis:Axis(title: "y-axis too"), autosize:false)
-    Plot[float64](layout:layout, datas: @[d]).show()
+                        yaxis: Axis(title: "y-axis too"), autosize: false)
+    Plot[float64](layout: layout, datas: @[d]).show()
 
   block:
-    var text = @["a", "b", "c", "d"]
-    var layout = Layout(title: "nim-plotly bar+scattter chart example", width: 1200, height: 400,
+    const text = @["a", "b", "c", "d"]
+    let layout = Layout(title: "nim-plotly bar+scattter chart example", width: 1200, height: 400,
                         xaxis: Axis(title:"category"),
                         yaxis: Axis(title:"value"), autosize:false)
 
-    var y = @[25.5'f64, 5, 9, 10.0]
-    var y2 = @[35.5'f64, 1, 19, 20.0]
-    var y3 = @[15.5'f64, 41, 29, 30.0]
-
-    var d1 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y, text:text, name: "first group")
-    var d2 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y2, text:text, name: "second group")
-    var d3 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.Bar, ys:y3, text:text, name: "third group")
-    var d4 = Trace[float64](mode:PlotMode.LinesMarkers, `type`: PlotType.ScatterGL, ys:y3, text:text, name: "scatter")
-    var d5 = Trace[float64](mode:PlotMode.Markers, `type`: PlotType.ScatterGL, ys:y, text:text, name: "just markers")
+    const
+      y = @[25.5'f64, 5, 9, 10.0]
+      y2 = @[35.5'f64, 1, 19, 20.0]
+      y3 = @[15.5'f64, 41, 29, 30.0]
+    let
+      # define some `Trace` instances showcasing different styles
+      d1 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y,
+                          text: text, name: "first group")
+      d2 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y2,
+                          text: text, name: "second group")
+      d3 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.Bar, ys: y3,
+                          text: text, name: "third group")
+      d4 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                          ys:y3, text: text, name: "scatter")
+      d5 = Trace[float64](mode: PlotMode.Markers, `type`: PlotType.ScatterGL, ys:y,
+                          text: text, name: "just markers")
     d5.marker = Marker[float64](size: @[25'f64])
 
-    Plot[float64](layout:layout, datas: @[d1, d2, d3, d4, d5]).show()
+    Plot[float64](layout: layout, datas: @[d1, d2, d3, d4, d5]).show()
 
 
   block:
 
     const n = 50
-    var y1 = new_seq[float64](n)
-    var y2 = new_seq[float64](n)
-    var x = new_seq[float64](n)
+    var y1 = newSeq[float64](n)
+    var y2 = newSeq[float64](n)
+    var x = newSeq[float64](n)
 
-    for i in 0..x.high:
+    for i in 0 .. x.high:
       x[i] = i.float64
       y1[i] = sin(i.float64) * 100
       y2[i] = cos(i.float64) / 100
 
-    var t1 = Trace[float64](mode:PlotMode.Lines, `type`: PlotType.Scatter, ys:y1, name: "sin*100")
-    var t2 = Trace[float64](mode:PlotMode.Lines, `type`: PlotType.Scatter, ys:y2, name: "cos/100", yaxis:"y2")
-    var layout = Layout(title: "multiple axes in nim plotly", width: 1200, height: 400,
-                        xaxis: Axis(title:"x"),
-                        yaxis: Axis(title:"sin"),
-                        yaxis2: Axis(title:"cos", side:PlotSide.Right), autosize:false)
+    let
+      t1 = Trace[float64](mode: PlotMode.Lines, `type`: PlotType.Scatter, ys: y1,
+                          name: "sin*100")
+      t2 = Trace[float64](mode: PlotMode.Lines, `type`: PlotType.Scatter, ys: y2,
+                          name: "cos/100", yaxis: "y2")
+      layout = Layout(title: "multiple axes in nim plotly", width: 1200, height: 400,
+                      xaxis: Axis(title:"x"),
+                      yaxis: Axis(title:"sin"),
+                      yaxis2: Axis(title:"cos", side: PlotSide.Right), autosize: false)
 
-    Plot[float64](layout:layout, datas: @[t1, t2]).show()
+    Plot[float64](layout: layout, datas: @[t1, t2]).show()

--- a/src/plotly/browser.nim
+++ b/src/plotly/browser.nim
@@ -2,12 +2,13 @@ import osproc
 import os
 import strutils
 
-proc hasExe*(cmd:string): bool =
+proc hasExe*(cmd: string): bool =
+  # Deprecated?
   let (outp, _) = execCmdEx(cmd)
   return not ("not found" in outp)
 
 const options = @["xdg-open", "mozilla-firefox", "firefox", "chromium", "google-chrome", "chromium-browser"]
-var browsers = new_seq[string]()
+var browsers = newSeq[string]()
 
 for o in options:
   var e = findExe(o)
@@ -15,7 +16,7 @@ for o in options:
   browsers.add(e)
 echo browsers
 
-proc open*(path:string) =
+proc open*(path: string) =
   ## open a browser pointing to the given path
   for b in browsers:
     var (outp, errC) = execCmdEx(b & " " & path)
@@ -25,4 +26,3 @@ proc open*(path:string) =
 
 when isMainModule:
   open("/tmp/x.html")
-

--- a/src/plotly/color.nim
+++ b/src/plotly/color.nim
@@ -8,6 +8,6 @@ func empty*(c: Color): bool =
   result = c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0
 
 func toHtmlHex*(colors: seq[Color]): seq[string] =
-  result = new_seq[string](len(colors))
+  result = newSeq[string](len(colors))
   for i, c in colors:
     result[i] = c.toHtmlHex

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -25,7 +25,7 @@ type
     ebkPercentAsym,      # asymmetric error on percent of value
     ebkSqrt,             # error based on sqrt of value
     ebkArraySym,         # symmetric error based on array of length data.len
-    ebkArrayAsym        # assymmetric error based on array of length data.len
+    ebkArrayAsym         # assymmetric error based on array of length data.len
 
   ErrorBar*[T: SomeNumber] = ref object
     visible*: bool


### PR DESCRIPTION
Since I had some free time and you mentioned that you're still relatively new to Nim, I thought I'd change the code somewhat to make it more idiomatic Nim style, i.e. apply the style guide 
https://nim-lang.org/docs/nep1.html
and the style of the standard library. I may be doing some non idiomatic things myself, so feel free to criticize (or just ignore it if you don't simply don't like it :) ).

What I changed:
- while new_seq is valid thanks to Nim's special calling syntax, it's not very idiomatic. camelCase is the preferred syntax for procedures.
- replaced all `var` declarations with `const` or `let` declarations, if possible
- introduced blocks of `let`, `var`, `const` where applicable
- made use of a couple more `result` variables, where not used before
- removed unnecessary type declarations for proc arguments, which have a default value, e.g.:
  ```nim
  proc newPlot*(xlabel = "", ylabel = "", title = ""): Plot[float64] =
  # instead of
  proc newPlot*(xlabel: string = "", ylabel: string = "", title: string = ""): Plot[float64] =
  ```
  since the compiler can also deduce it automatically here.
- introduced some spaces around things like `argument:type`.
- I (almost) enforced the 80 column rule everywhere (unless I missed it somewhere). That may be a little 
  excessive, but after I started...

Note: this PR is based on PR #4, so that should be merged before hand (if you decide to merge this anyways ;) ).
I hope you don't mind me doing this. :)