### PR TITLE
Added command for default browser in Mac OS

### DIFF
--- a/src/plotly/browser.nim
+++ b/src/plotly/browser.nim
@@ -7,7 +7,7 @@ proc hasExe*(cmd: string): bool =
   let (outp, _) = execCmdEx(cmd)
   return not ("not found" in outp)
 
-const options = @["xdg-open", "mozilla-firefox", "firefox", "chromium", "google-chrome", "chromium-browser"]
+const options = @["xdg-open", "open", "mozilla-firefox", "firefox", "chromium", "google-chrome", "chromium-browser"]
 var browsers = newSeq[string]()
 
 for o in options:


### PR DESCRIPTION
The command "open" is used in Mac OS to open default browser in Mac OS with the URL as argument, like:

**open** https://github.com

This is also how Safari can be utilized as well, since, on Mac OS one cannot open a URL through terminal in Safari without this method (except using apple script which would be very much tedious here).