### PR TITLE
add different options to change histogram settings (bin size etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/brentp/nim-plotly.svg?branch=master)](https://travis-ci.org/brentp/nim-plotly)
 
 This is a functioning plotting library. It supports, *line* (with fill below), *scatter* (with errors), *bar*
-, *histogram*, and combinations of those plot types. More standard types can be added on request.
+, *histogram*, *heatmap*, *candlestick* and combinations of those plot types. More standard types can be added on request.
 
 
 This is **not** specifically for the javascript nim target (but the

--- a/examples/all.nim
+++ b/examples/all.nim
@@ -7,3 +7,4 @@ import fig6_histogram
 import fig7_stacked_histogram
 import fig9_heatmap
 import fig10_candlestick
+import fig11_histogram_settings

--- a/examples/fig11_histogram_settings.nim
+++ b/examples/fig11_histogram_settings.nim
@@ -1,0 +1,101 @@
+import plotly
+import math
+import sequtils
+import mersenne
+
+proc gauss(x, mean, sigma: float): float =
+  # unsafe helper proc producing gaussian distribution
+  let arg = (x - mean) / sigma
+  result = exp(-0.5 * arg * arg) / sqrt(2 * PI)
+
+proc draw(samples: int): seq[float] =
+  # create some gaussian data (not very efficient :))
+  var random = newMersenneTwister(42)
+  const
+    mean = 0.5
+    sigma = 0.1
+  result = newSeqOfCap[float](samples)
+  while result.len < samples:
+    let
+      r = random.getNum().float / uint32.high.float
+      rejectProb = gauss(r, mean, sigma)
+    if (random.getNum().float / uint32.high.float) < rejectProb:
+      result.add r
+
+var data = draw(10_000)
+
+
+# The following simply showcases a few different ways to set different binning
+# ranges and sizes
+# NOTE: the `nBins` field of a histogram does not force that number of bins!
+# It is merely used as an input for plotly's autobinning algorithm. `nBins`
+# is the maximum number of allowed bins. But in some cases it might decide
+# that a few bins less visualize the data better. Plotly's description states:
+#   "Specifies the maximum number of desired bins. This value will be used in
+#    an algorithm that will decide the optimal bin size such that the histogram
+#    best visualizes the distribution of the data."
+block:
+  let
+    d = Trace[float](`type`: PlotType.Histogram, cumulative: true,
+                     # set a range for the bins and a bin size
+                     bins: (0.0, 1.0), binSize: 0.01)
+  d.xs = data
+  let
+    layout = Layout(title: "cumulative histogram in range (0.0 / 1.0) with custom bin size and range",
+                    width: 1200, height: 800,
+                    # set the range of the axis manually. If not, plotly may not show
+                    # empty bins in its range
+                    xaxis: Axis(title:"values", range: (0.0, 1.0)),
+                    yaxis: Axis(title: "counts"),
+                    autosize: false)
+    p = Plot[float](layout: layout, traces: @[d])
+  p.show()
+
+block:
+  let
+    d = Trace[float](`type`: PlotType.Histogram, cumulative: true,
+                     nBins: 100)
+  d.xs = data
+  let
+    layout = Layout(title: "cumulative histogram in range (0.0 / 1.0) with specific max number of bins",
+                    width: 1200, height: 800,
+                    # set the range of the axis manually. If not, plotly may not show
+                    # empty bins in its range                    
+                    xaxis: Axis(title:"values", range: (0.0, 1.0)),
+                    yaxis: Axis(title: "counts"),
+                    autosize: false)
+    p = Plot[float](layout: layout, traces: @[d])
+  p.show()
+
+block:
+  # here we only specify the number of bins, but not the bin range nor the axis
+  # range. This may result in less than 50 bins (if some bins slightly wider bins
+  # fit better according to plotly's algorithm). Additionally, the range of the
+  # plot may be cut to bins which contain data.
+  let
+    d = Trace[float](`type`: PlotType.Histogram, nBins: 50)
+  d.xs = data
+  let
+    layout = Layout(title: "histogram in automatic range with specific max number of bins",
+                    width: 1200, height: 800,
+                    xaxis: Axis(title:"values"),
+                    yaxis: Axis(title: "counts"),
+                    autosize: false)
+    p = Plot[float](layout: layout, traces: @[d])
+  p.show()
+
+block:
+  # Setting the bin size and bin range manually. Without specifying the axis range
+  # empty bins may still be discarded from the range.
+  let
+    d = Trace[float](`type`: PlotType.Histogram,
+                     bins: (0.0, 1.0), binSize: 0.05)
+  d.xs = data
+  let
+    layout = Layout(title: "histogram in automatic range with specific bin range and size",
+                    width: 1200, height: 800,
+                    xaxis: Axis(title:"values"),
+                    yaxis: Axis(title: "counts"),
+                    autosize: false)
+    p = Plot[float](layout: layout, traces: @[d])
+  p.show()

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -9,7 +9,7 @@ import plotly_types
 import color
 import errorbar
 
-func parseHistogramFields[T](fields: var OrderedTable[string, JsonNode], t: Trace[T]) = 
+func parseHistogramFields[T](fields: var OrderedTable[string, JsonNode], t: Trace[T]) =
   ## parse the fields of the histogram type. Usese a separate proc
   ## for clarity.
   fields["cumulative"] = %* {
@@ -29,7 +29,7 @@ func parseHistogramFields[T](fields: var OrderedTable[string, JsonNode], t: Trac
     # if nbins is set, this provides the maximum number of bins allowed to be
     # calculated by the autobins algorithm
     fields[&"autobin{bars}"] = % true
-    
+
   elif t.bins.start != t.bins.stop:
     fields[&"{bars}bins"] = %* {
       "start" : % t.bins.start,
@@ -63,6 +63,14 @@ func `%`*(a: Axis): JsonNode =
   if a.side != PlotSide.Unset:
     fields["side"] = % a.side
     fields["overlaying"] = % "y"
+
+  if a.range.start != a.range.stop:
+    fields["autorange"] = % false
+    # range is given as an array of two elements, start and stop
+    fields["range"] = % [a.range.start, a.range.stop]
+  else:
+    fields["autorange"] = % true
+
   if a.rangeslider != nil:
     fields["rangeslider"] = % a.rangeslider
 
@@ -143,7 +151,7 @@ func `%`*(t: Trace): JsonNode =
     fields["x"] = % t.xs
   if t.yaxis != "":
     fields["yaxis"] = % t.yaxis
-    
+
   if t.opacity != 0:
     fields["opacity"] = % t.opacity
 
@@ -156,7 +164,7 @@ func `%`*(t: Trace): JsonNode =
     # heatmap stores data in z only
     if t.zs != nil:
       fields["z"] = % t.zs
-      
+
     fields["colorscale"] = % t.colormap
   of PlotType.Candlestick:
     fields["open"] = % t.open

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -24,18 +24,20 @@ func parseHistogramFields[T](fields: var OrderedTable[string, JsonNode], t: Trac
   if t.xs == nil or t.xs.len == 0:
     bars = "y"
 
-  # if either nbins or start / stop range given, disable auto binning
-  if anyIt([t.nbins.float, t.bins.start, t.bins.stop], it > 0.0):
-    fields[&"autobins{bars}"] = % false
-
   if t.nbins > 0:
-    fields[&"nbins{bars}"] = % t.nbins    
+    fields[&"nbins{bars}"] = % t.nbins
+    # if nbins is set, this provides the maximum number of bins allowed to be
+    # calculated by the autobins algorithm
+    fields[&"autobin{bars}"] = % true
+    
   elif t.bins.start != t.bins.stop:
     fields[&"{bars}bins"] = %* {
       "start" : % t.bins.start,
       "end" : % t.bins.stop,
       "size" : % t.binSize
     }
+    # in case bins are set manually, disable autobins
+    fields[&"autobin{bars}"] = % false
 
 func `%`*(c: Color): string =
   result = c.toHtmlHex()

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -165,6 +165,8 @@ type
     domain*: seq[float64]
     side*: PlotSide
     rangeslider*: RangeSlider
+    # setting no range implies plotly's `autorange` true
+    range*: tuple[start, stop: float]
 
   Layout* = ref object
     title*: string

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -13,6 +13,21 @@ type
     HeatMapGL = "heatmapgl"
     Candlestick = "candlestick"
 
+  HistFunc* {.pure.} = enum
+    # count is plotly.js default
+    Count = "count"
+    Sum = "sum"
+    Avg = "avg"
+    Min = "min"
+    Max = "max"
+
+  HistNorm* {.pure.} = enum
+    None = ""
+    Percent = "percent"
+    Probability = "probability"
+    Density = "density"
+    ProbabilityDensity = "probability density"
+
   PlotFill* {.pure.} = enum
     Unset = ""
     ToNextY = "tonexty"
@@ -123,6 +138,16 @@ type
       high*: seq[T]
       low*: seq[T]
       close*: seq[T]
+    of Histogram:
+      histFunc*: HistFunc
+      histNorm*: HistNorm
+      # TODO: include increasing and decreasing distinction?
+      cumulative*: bool
+      # if `nBins` is set, the `bins` tuple and `binSize` will be ignored
+      nBins*: int
+      bins*: tuple[start, stop: float]
+      # `binSize` is optional, even if `bins` is given.
+      binSize*: float
     else:
       discard
 


### PR DESCRIPTION
I started adding more options to customize histogram plots. It's now possible to
set different bin numbers, bin ranges, bin sizes, create cumulative
and normalized histograms.

To keep the `%` func for `Trace` a little cleaner, I added a `parseHistogramFields` func, which adds the histogram related fields to the result.

I'll add an example in the soon, that's why I mark this WIP.