### PR TITLE
Creating tempDir and absolute path

### DIFF
--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -61,7 +61,9 @@ when not defined(js):
   proc save*(p: Plot, path = "", html_template = defaultTmplString): string =
     result = path
     if result == "":
-      result = "/tmp/x.html"
+      let tempDir = parentDir(currentSourcePath()) / "tmp"
+      createDir(tempDir)
+      result = tempDir / "x.html"
 
     let data_string = parseTraces(p.traces)
 

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -61,9 +61,10 @@ when not defined(js):
   proc save*(p: Plot, path = "", html_template = defaultTmplString): string =
     result = path
     if result == "":
-      let tempDir = parentDir(currentSourcePath()) / "tmp"
-      createDir(tempDir)
-      result = tempDir / "x.html"
+      when defined(Windows):
+        result = getEnv("TEMP") / "x.html"
+      else:
+        result = "/tmp/x.html"
 
     let data_string = parseTraces(p.traces)
 


### PR DESCRIPTION
On windows save failed, because there was no temp directory and it didn't like the relative path, so I changed it to create the temp dir and use a absolute path.