### PR TITLE
Add ability to save plots as png, jpg, svg, webp

### DIFF
--- a/examples/all.nim
+++ b/examples/all.nim
@@ -8,3 +8,4 @@ import fig7_stacked_histogram
 import fig9_heatmap
 import fig10_candlestick
 import fig11_histogram_settings
+import fig12_save_figure

--- a/examples/fig12_save_figure.nim
+++ b/examples/fig12_save_figure.nim
@@ -1,0 +1,27 @@
+import plotly
+import chroma
+
+const colors = @[Color(r:0.9, g:0.4, b:0.0, a: 1.0),
+                 Color(r:0.9, g:0.4, b:0.2, a: 1.0),
+                 Color(r:0.2, g:0.9, b:0.2, a: 1.0),
+                 Color(r:0.1, g:0.7, b:0.1, a: 1.0),
+                 Color(r:0.0, g:0.5, b:0.1, a: 1.0)]
+let
+  d = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.Scatter)
+  size = @[16.int]
+d.marker = Marker[int](size: size, color: colors)
+d.xs = @[1, 2, 3, 4, 5]
+d.ys = @[1, 2, 1, 9, 5]
+d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
+
+let
+  layout = Layout(title: "Saving a figure!", width: 1200, height: 400,
+                  xaxis: Axis(title:"my x-axis"),
+                  yaxis: Axis(title: "y-axis too"),
+                  autosize: false)
+  p = Plot[int](layout: layout, traces: @[d])
+# now call the show proc with the `filename` argument to save the
+# file with the given filetype
+# p.show(filename = "HelloImage.png")
+# alternatively call the `saveImage` proc instead of show
+p.saveImage("HelloImage.svg")

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -112,6 +112,12 @@ when not defined(js):
     f.write(s)
     f.close()
 
+  proc saveImage*(p: Plot, filename: string) =
+    ## saves the image under the given filename
+    ## supported filetypes:
+    ## - jpg, png, svg, webp
+    p.show(filename = filename)
+
 when isMainModule:
   import math
 

--- a/src/plotly/image_retrieve.nim
+++ b/src/plotly/image_retrieve.nim
@@ -1,0 +1,116 @@
+import websocket, asynchttpserver, asyncnet, asyncdispatch
+import strutils, strformat
+import re
+import os
+# to decode SVG data
+import uri
+# to decode jpeg, png and webp data
+import base64
+
+type
+  # simple type for clarity, ``Connected`` package first sent after
+  # connection to websocket server has been established
+  Message {.pure.} = enum
+    Connected = "connected"
+
+proc parseImageType*(filename: string): string =
+  let
+    (dir, file, ext) = filename.splitFile  
+    filetype = ext.strip(chars = {'.'})
+  # now check for the given type
+  case filetype
+  of "jpg":
+    # plotly expects the filetype to be given as ".jpeg"
+    result = "jpeg"
+  of "jpeg", "png", "svg", "webp":
+    result = filetype
+  else:
+    echo "Warning: Only the following filetypes are allowed:"
+    echo "\t jpeg, svg, png, webp"
+    echo "will save file as png"
+    result = "png"
+
+# data header which we use to insert the filetype and then strip
+# it from the data package
+# jpeg header = data:image/jpeg;base64,
+# png header  = data:image/png;base64,
+# webp header = data:image/webp;base64,
+# svg header  = data:image/svg+xml,
+# template for jpg, png and webp
+const base64Tmpl = r"data:image/$#;base64,"
+# template for svg
+const urlTmpl = r"data:image/$#+xml,"
+
+# use a channel to hand the filename to the callback function
+var
+  filenameChannel: Channel[string]
+filenameChannel.open(1)
+
+template parseFileType(header: string, regex: Regex): string =
+  # template due to GC safety. Just have it replaced in code below
+  var result = ""
+  if header =~ regex:
+    # pipe output through ``parseImageType``
+    result = matches[0]
+  else:
+    # default to png
+    result = "png"
+  result
+
+proc cb(req: Request) {.async.} =
+  # compile regex to parse the data header
+  let regex = re(r"data:image\/(\w+)[;+].*")
+  # receive the filename from the channel
+  let filename = filenameChannel.recv()
+  
+  # now await the connection of the websocket client
+  let (ws, error) = await verifyWebsocketRequest(req)
+
+  if ws.isNil:
+    echo "WS negotiation failed: ", error
+    await req.respond(Http400, "Websocket negotiation failed: " & error)
+    req.client.close()
+    return
+  else:
+    # receive connection successful package
+    let (opcodeConnect, dataConnect) = await ws.readData()
+    if dataConnect == $Message.Connected:
+      echo "Plotly connected successfully!"
+    else:
+      echo "Connection broken :/"
+      return
+
+  # now await the actual data package
+  let (opcode, data) = await ws.readData()
+  # get header to parse the actual filetype and remove the header from the data
+  # determine header length from data, first appearance of `,`
+  let headerLength = data.find(',')
+  let
+    header = (data.strip)[0 .. headerLength]
+    filetype = header.parseFileType(regex)
+  var
+    onlyData = ""
+    image = ""
+  case filetype
+  of "jpeg", "png", "webp":
+    onlyData = data.replace(base64Tmpl % filetype, "")
+    # decode the base64 decoded data packet
+    image = (onlyData).decode
+  of "svg":
+    onlyData = data.replace(urlTmpl % filetype, "")
+    # decode the URI decoded data packet
+    image = onlyData.decodeUrl
+  else:
+    echo "Warning: Unsupported filetype :", filetype
+  try:
+    # try to write the filename the user requested
+    writeFile(filename, image)
+  except IOError:
+    echo "Warning: file could not be written to ", filename
+
+proc listenForImage*(filename: string) = 
+  let server = newAsyncHttpServer()
+  echo "Saving plot to file ", filename
+  filenameChannel.send(filename)
+  waitFor server.serve(Port(8080), cb)
+  

--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -10,7 +10,34 @@ const defaultTmplString = """
 		<div id="plot0"></div>
 		<script>
 			Plotly.newPlot('plot0', $data, $layout)
-		</script>
+                </script>
+                $saveImage
 	</body>
 </html>
 """
+
+# type needs to be inserted!
+# either
+# - png
+# - svg
+# - jpg
+const injectImageCode = """
+<script>
+        var d3 = Plotly.d3;
+        var imageData;
+        var img = d3.select('#$1-export');
+        Plotly.toImage(plot0, {format: '$2', width: $3, height: $4}).then(function(url){
+                img.attr("src", url);
+                imageData = url;
+                return Plotly.toImage(plot0,{format:'$5', width: $6, height: $7});
+              })
+        var connection = new WebSocket('ws://localhost:8080');
+        // after connection opened successfully, send our image
+        connection.onopen = function() {
+          // need to wait a short while to be sure the promise is fullfilled (I believe?!)
+          connection.send("connected")
+          setTimeout(function(){ connection.send(imageData); }, 100);
+};
+</script>
+"""
+


### PR DESCRIPTION
This commit is introduces the ability to save the plots created by plotly directly to file.
Normally one needs to use the plotly user interface to save the plots. This is 
1. inconvenient if one needs to store more than one or two images
2. it only allows to store the images as png.

With this somewhat complicated workaround, we can save the images as
- png
- jpg
- webp
- svg (as a proper vector graphic!)

It works by injecting a few more lines of Javascript code into the HTML template, which uses `Plotly.toImage` to create a data packet of the desired size and filetype from the plot. We then open a websocket connection and send the image data to a websocket server, which we start before we open the browser. 
That server (see `image_retrieve`) decodes the image data and saves it to file.

The downside to this implementation is that we have to compile plotly with `--threads:on`. 

Maybe there's an easier way to accomplish this, but I wanted to have the plots as svg files and this was the only way I know to make it work. :)