### PR TITLE
fixes #23 by adding `jsbind` dependency, change js filename in html

### DIFF
--- a/examples/index_javascript.html
+++ b/examples/index_javascript.html
@@ -10,6 +10,6 @@
 <div id="lineplot"><!-- Line plot chart will be drawn inside this DIV --></div>
 <br>
 
-<script type="text/javascript" src="nimcache/fig_javascript.js"></script>
+<script type="text/javascript" src="nimcache/fig8_js_interactive.js"></script>
 </body>
 </html>

--- a/plotly.nimble
+++ b/plotly.nimble
@@ -6,7 +6,7 @@ description   = "plotting library for nim"
 license       = "MIT"
 
 
-requires "nim >= 0.18.0", "chroma", "websocket"
+requires "nim >= 0.18.0", "chroma", "websocket", "jsbind"
 srcDir = "src"
 
 skipDirs = @["tests"]


### PR DESCRIPTION
The dependency for `jsbind` was missing in the nimble file. Also changes the Html template to run the javascript example to match the filename of the example.