### PR TITLE
Add support for contour plots

### DIFF
--- a/examples/all.nim
+++ b/examples/all.nim
@@ -8,3 +8,4 @@ import fig7_stacked_histogram
 import fig9_heatmap
 import fig10_candlestick
 import fig11_histogram_settings
+import fig13_contour

--- a/examples/fig13_contour.nim
+++ b/examples/fig13_contour.nim
@@ -1,0 +1,30 @@
+import plotly
+import sequtils
+
+let
+  d = Trace[float32](`type`: PlotType.Contour)
+
+d.xs = @[-2.0, -1.5, -1.0, 0.0, 1.0, 1.5, 2.0, 2.5].mapIt(it.float32)
+d.ys = @[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6].mapIt(it.float32)
+  # The data needs to be supplied as a nested seq.
+d.zs = @[@[2, 4, 7, 12, 13, 14, 15, 16],
+         @[3, 1, 6, 11, 12, 13, 16, 17],
+         @[4, 2, 7, 7, 11, 14, 17, 18],
+         @[5, 3, 8, 8, 13, 15, 18, 19],
+         @[7, 4, 10, 9, 16, 18, 20, 19],
+         @[9, 10, 5, 27, 23, 21, 21, 21],
+         @[11, 14, 17, 26, 25, 24, 23, 22]].mapIt(it.mapIt(it.float32))
+
+d.colorscale = ColorMap.Jet
+# d.heatmap = true # smooth colors
+# d.smoothing = 0.001 # rough lines
+# d.contours = (2.0, 26.0, 4.0)
+
+let
+  layout = Layout(title: "Contour example", width: 600, height: 600,
+                  xaxis: Axis(title: "x-axis"),
+                  yaxis: Axis(title: "y-axis"), autosize: false)
+  p = Plot[float32](layout: layout, traces: @[d])
+
+echo p.save()
+p.show()

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -151,6 +151,10 @@ func `%`*(t: Trace): JsonNode =
       fields["x"] = % t.text
   else:
     fields["x"] = % t.xs
+
+  if t.ys.len > 0:
+    fields["y"] = % t.ys
+
   if t.yaxis != "":
     fields["yaxis"] = % t.yaxis
 
@@ -168,6 +172,25 @@ func `%`*(t: Trace): JsonNode =
       fields["z"] = % t.zs
 
     fields["colorscale"] = % t.colormap
+  of PlotType.Contour:
+    if t.zs.len > 0: fields["z"] = % t.zs
+    fields["colorscale"] = % t.colorscale
+    if t.contours.start != t.contours.stop:
+      fields["autocontour"] = % false
+      fields["contours"] = %* {
+        "start" : % t.contours.start,
+        "end" : % t.contours.stop,
+        "size" : % t.contours.size
+      }
+    else:
+      fields["autocontour"] = % true
+      fields["contours"] = %* {}
+    if t.heatmap:
+      fields["contours"]["coloring"] = % "heatmap"
+    if t.smoothing > 0:
+      fields["line"] = %* {
+        "smoothing": % t.smoothing
+      }
   of PlotType.Candlestick:
     fields["open"] = % t.open
     fields["high"] = % t.high
@@ -175,11 +198,8 @@ func `%`*(t: Trace): JsonNode =
     fields["close"] = % t.close
   of PlotType.Histogram:
     fields.parseHistogramFields(t)
-    if t.ys.len > 0:
-      fields["y"] = % t.ys
   else:
-    if t.ys.len > 0:
-      fields["y"] = % t.ys
+    discard
 
   if t.xs_err != nil:
     fields["error_x"] = % t.xs_err

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -11,6 +11,7 @@ type
     HeatMap = "heatmap"
     HeatMapGL = "heatmapgl"
     Candlestick = "candlestick"
+    Contour = "contour"
 
   HistFunc* {.pure.} = enum
     # count is plotly.js default
@@ -130,6 +131,12 @@ type
     case `type`*: PlotType
     of HeatMap, HeatMapGL:
       colormap*: ColorMap
+    of Contour:
+      colorscale*: ColorMap
+      # setting no contours implies `autocontour` true
+      contours*: tuple[start, stop, size: float]
+      heatmap*: bool
+      smoothing*: float
     # case on `type`, since we only need Close,High,Low,Open for
     # PlotType.Candlestick
     of Candlestick:


### PR DESCRIPTION
This PR introduces basic support for contour plots, see https://plot.ly/python/contour-plots/
Contour plots are useful for displaying decision boundaries of some deep learning models.
A new example script shows usage of the implemented settings.

Note that `fields["y"]` setting was moved out of histogram branch to all plot types, 
hopefully this does not break anything.
