### PR TITLE
Make `color` argument for `newErrorBar` optional

### DIFF
--- a/examples/fig5_errorbar.nim
+++ b/examples/fig5_errorbar.nim
@@ -16,25 +16,27 @@ d.marker = Marker[float](size: size, color: colors)
 d.xs = @[1'f64, 2, 3, 4, 5]
 d.ys = @[1'f64, 2, 1, 9, 5]
 
+# Note: all `newErrorBar` procs receive an optional `color` argument
+
 # example of constant error
-# d.xs_err = newErrorBar(0.5, color = colors[0])
+# d.xs_err = newErrorBar(0.5)
 # example of constant percentual error. Note that the value given is in actual
 # percent and not a ratio
-# d.xs_err = newErrorBar(10.0, color = colors[0], percent = true)
+# d.xs_err = newErrorBar(10.0, percent = true)
 # example of an asymmetric error bar on x
 d.xs_err = newErrorBar((0.1, 0.25), color = colors[0])
 
 # create a sequence of increasing error bars for y
 let yerrs = mapIt(toSeq(0..5), it.float * 0.25)
-d.ys_err = newErrorBar(yerrs, color = colors[0])
+d.ys_err = newErrorBar(yerrs)
 # import algorithm
 # example of asymmetric error bars for each element
 # let yerrs_high = @[0.1, 0.2, 0.3, 0.4, 0.5].reversed
-# d.ys_err = newErrorBar((yerrs_low, yerrs_high), color = colors[0])
+# d.ys_err = newErrorBar((yerrs_low, yerrs_high))
 # example of a sqrt error on y. Need to hand the correct type here manually,
 # otherwise we'll get a "cannot instantiate `ErrorBar[T]`" error, due to
 # no value from which type can be deduced is present
-# d.ys_err = newErrorBar[float](color = colors[0])
+# d.ys_err = newErrorBar[float]()
 
 d.text = @["hello", "data-point", "third", "highest", "<b>bold</b>"]
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -169,7 +169,8 @@ func `%`*(b: ErrorBar): JsonNode =
   ## creates a JsonNode from an `ErrorBar` object depending on the object variant
   var fields = initOrderedTable[string, JsonNode](4)
   fields["visible"] = % b.visible
-  fields["color"] = % b.color.toHtmlHex
+  if b.color != empty():
+    fields["color"] = % b.color.toHtmlHex
   if b.thickness > 0:
     fields["thickness"] = % b.thickness
   if b.width > 0:

--- a/src/plotly/color.nim
+++ b/src/plotly/color.nim
@@ -2,6 +2,9 @@ import chroma
 
 # this module contains utility functions used in other modules of plotly
 # related to the chroma module
+func empty*(): Color =
+  ## returns completely black
+  result = Color(r: 0, g: 0, b: 0, a: 0)
 
 func empty*(c: Color): bool =
   # TODO: this is also black, but should never need black with alpha == 0

--- a/src/plotly/errorbar.nim
+++ b/src/plotly/errorbar.nim
@@ -2,12 +2,14 @@ import chroma
 
 # plotly internal modules
 import plotly_types
+import color
 
 # this module contains all procedures related to the `ErrorBar` class
 # e.g. convenience functions to create a new `ErrorBar` object
 
-func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 0.0,
-                                 visible = true, percent = false): ErrorBar[T] =
+func newErrorBar*[T: SomeNumber](err: T, color: Color = empty(), thickness = 0.0,
+                                 width = 0.0, visible = true, percent = false):
+                                   ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkConstantSym` or `ebkPercentSym`, if the `percent` flag
   ## is set to `true`
   # NOTE: there is a lot of visual noise in the creation here... change how?
@@ -20,8 +22,9 @@ func newErrorBar*[T: SomeNumber](err: T, color: Color, thickness = 0.0, width = 
                          width: width, kind: ebkPercentSym)
     result.percent = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[m, p: T], color: Color, thickness = 0.0,
-                                 width = 0.0, visible = true, percent = false): ErrorBar[T] =
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: T], color: Color = empty(),
+                                 thickness = 0.0, width = 0.0, visible = true,
+                                 percent = false): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkConstantAsym`, constant plus and
   ## minus errors given as tuple or `ebkPercentAsym` of `percent` flag is set to true
   ## Note: the first element of the `err` tuple is the `negative` size, the second
@@ -37,20 +40,20 @@ func newErrorBar*[T: SomeNumber](err: tuple[m, p: T], color: Color, thickness = 
     result.percentPlus  = err.p
     result.percentMinus = err.m
 
-func newErrorBar*[T: SomeNumber](color: Color, thickness = 0.0, width = 0.0,
-                                 visible = true): ErrorBar[T] =
+func newErrorBar*[T: SomeNumber](color: Color = empty(), thickness = 0.0,
+                                 width = 0.0, visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkSqrt`
   result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
                          width: width, kind: ebkSqrt)
 
-func newErrorBar*[T](err: seq[T], color: Color, thickness = 0.0, width = 0.0,
-                     visible = true): ErrorBar[T] =
+func newErrorBar*[T](err: seq[T], color: Color = empty(), thickness = 0.0,
+                     width = 0.0, visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkArraySym`
   result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
                        width: width, kind: ebkArraySym)
   result.errors = err
 
-func newErrorBar*[T: SomeNumber](err: tuple[m, p: seq[T]], color: Color,
+func newErrorBar*[T: SomeNumber](err: tuple[m, p: seq[T]], color: Color = empty(),
                                  thickness = 0.0, width = 0.0, visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkArrayAsym`, where the first
   ## Note: the first seq of the `err` tuple is the `negative` error seq, the second


### PR DESCRIPTION
This PR is based on https://github.com/brentp/nim-plotly/pull/21. Still needs to be rebased on the contour PR, too.

Sorry, my fault. I've realized that the usability suffers a lot from having to define a color just to use error bars.