### PR TITLE
add coloring of markers based on `seq[T: SomeNumber]`

### DIFF
--- a/examples/fig2_scatter_colors_sizes.nim
+++ b/examples/fig2_scatter_colors_sizes.nim
@@ -2,6 +2,7 @@ import plotly
 import math
 import chroma
 
+
 const
   n = 70
   color_choice = @[Color(r: 0.9, g: 0.1, b: 0.1, a: 1.0),
@@ -13,7 +14,6 @@ var
   text = new_seq[string](n)
   colors = new_seq[Color](n)
   sizes = new_seq[float64](n)
-
 for i in 0 .. y.high:
   x[i] = i.float
   y[i] = sin(i.float)
@@ -25,11 +25,21 @@ for i in 0 .. y.high:
     colors[i] = color_choice[1]
   text[i] = text[i] & "<b>" & colors[i].toHtmlHex() & "</b>"
 
-let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
-                       xs: x, ys: y, text: text)
-d.marker = Marker[float64](size: sizes, color: colors)
+block:
+  let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                         xs: x, ys: y, text: text)
+  d.marker = Marker[float64](size: sizes, color: colors)
 
-let layout = Layout(title: "saw the sin", width: 1200, height: 400,
-                    xaxis: Axis(title: "my x-axis"),
-                    yaxis: Axis(title: "y-axis too"), autosize: false)
-Plot[float64](layout: layout, traces: @[d]).show()
+  let layout = Layout(title: "saw the sin", width: 1200, height: 400,
+                      xaxis: Axis(title: "my x-axis"),
+                      yaxis: Axis(title: "y-axis too"), autosize: false)
+  Plot[float64](layout: layout, traces: @[d]).show()
+block:
+  let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                         xs: x, ys: y, text: text)
+  d.marker = Marker[float64](size: sizes, colorVals: y, colorMap: ColorMap.Viridis)
+
+  let layout = Layout(title: "saw the sin, colors of sin value!", width: 1200, height: 400,
+                      xaxis: Axis(title: "my x-axis"),
+                      yaxis: Axis(title: "y-axis too"), autosize: false)
+  Plot[float64](layout: layout, traces: @[d]).show()

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -296,6 +296,11 @@ func `%`*(m: Marker): JsonNode =
       fields["color"] = % m.color[0].toHtmlHex()
     else:
       fields["color"] = % m.color.toHtmlHex()
+  elif m.colorVals.len > 0:
+    fields["color"] = % m.colorVals
+    fields["colorscale"] = % m.colormap
+    fields["showscale"] = % true
+
   result = JsonNode(kind: Jobject, fields: fields)
 
 func `$`*(d: Trace): string =

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -122,6 +122,10 @@ type
   Marker*[T: SomeNumber] = ref object
     size*: seq[T]
     color*: seq[Color]
+    # alternatively use sequence of values defining color based on one of
+    # the color maps
+    colorVals*: seq[T]
+    colormap*: ColorMap
 
   Trace*[T: SomeNumber] = ref object
     xs*: seq[T]


### PR DESCRIPTION
Instead of only allowing colors based on `Color` objects, also allow maker
colors based on numbers, defined by a ColorMap.

Done by adding a `colorVals` and `colormap` field to the `Marker` object.