### PR TITLE
Add `Legend` object, allow more color customization

### DIFF
--- a/examples/fig17_colorFontLegend.nim
+++ b/examples/fig17_colorFontLegend.nim
@@ -1,0 +1,57 @@
+import plotly
+import math
+import chroma
+
+
+const
+  n = 70
+
+var
+  y = newSeq[float64](n)
+  x = newSeq[float64](n)
+  y2 = newSeq[float64](n)
+  x2 = newSeq[float64](n)
+  sizes = newSeq[float64](n)
+for i in 0 .. y.high:
+  x[i] = i.float
+  y[i] = sin(i.float)
+  x2[i] = (i.float + 0.5)
+  y2[i] = i.float * 0.1
+  sizes[i] = float64(10 + (i mod 10))
+
+let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                       xs: x, ys: y)
+let d2 = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                       xs: x2, ys: y2)
+d.marker = Marker[float64](size: sizes)
+
+let legend = Legend(x: 0.1,
+                    y: 0.9,
+                    backgroundColor: color(0.6, 0.6, 0.6),
+                    orientation: Vertical,
+                    font: Font(color: color())
+)
+
+let layout = Layout(title: "saw the sin", width: 800, height: 600,
+                    xaxis: Axis(title: "my x-axis"),
+                    yaxis: Axis(title: "y-axis too"),
+                    autosize: false,
+                    backgroundColor: color(0.92, 0.92, 0.92),
+                    legend: legend,
+                    showLegend: true
+)
+
+Plot[float64](layout: layout, traces: @[d, d2]).show()
+
+# alternatively using plotly_sugar
+# scatterPlot(x, y)
+#   .addTrace(scatterTrace(x2, y2))
+#   .mode(LinesMarkers)
+#   .markerSizes(sizes)
+#   .legend(legend)
+#   .xlabel("my x-axis")
+#   .ylabel("y-axis too")
+#   .backgroundColor(color(0.92, 0.92, 0.92))
+#   .width(800)
+#   .height(600)
+#   .show()

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -138,6 +138,10 @@ func `%`*(a: Axis): JsonNode =
   if a.rangeslider != nil:
     fields["rangeslider"] = % a.rangeslider
 
+  if not a.gridColor.empty:
+    fields["gridcolor"] = % a.gridColor
+  if a.gridWidth != 0:
+    fields["gridwidth"] = % a.gridWidth
 
   result = JsonNode(kind: JObject, fields: fields)
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -180,7 +180,7 @@ func `%`*(b: ErrorBar): JsonNode =
   ## creates a JsonNode from an `ErrorBar` object depending on the object variant
   var fields = initOrderedTable[string, JsonNode](4)
   fields["visible"] = % b.visible
-  if b.color != empty():
+  if not b.color.empty:
     fields["color"] = % b.color.toHtmlHex
   if b.thickness > 0:
     fields["thickness"] = % b.thickness

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -101,8 +101,8 @@ func parseBarFields[T](fields: var OrderedTable[string, JsonNode], t: Trace[T]) 
     fields["orientation"] = % t.orientation
   else: discard
 
-func `%`*(c: Color): string =
-  result = c.toHtmlHex()
+func `%`*(c: Color): JsonNode =
+  result = % c.toHtmlHex()
 
 func `%`*(f: Font): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -193,10 +193,10 @@ func `%`*(l: Layout): JsonNode =
     fields["hovermode"] = % l.hovermode
   if 0 < l.annotations.len:
     fields["annotations"] = % l.annotations
-  if not l.plotBgColor.empty:
-    fields["plot_bgcolor"] = % l.plotBgColor
-  if not l.paperBgColor.empty:
-    fields["paper_bgcolor"] = % l.paperBgColor
+  if not l.backgroundColor.empty:
+    fields["plot_bgcolor"] = % l.backgroundColor
+  if not l.paperColor.empty:
+    fields["paper_bgcolor"] = % l.paperColor
 
   result = JsonNode(kind: JObject, fields: fields)
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -108,8 +108,8 @@ func `%`*(f: Font): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if f.size != 0:
     fields["size"] = % f.size
-  if f.color.empty:
-    fields["color"] = % f.color.toHtmlHex()
+  if not f.color.empty:
+    fields["color"] = % f.color
   if f.family.len > 0:
     fields["family"] = % f.family
   result = JsonNode(kind: Jobject, fields: fields)

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -193,6 +193,10 @@ func `%`*(l: Layout): JsonNode =
     fields["hovermode"] = % l.hovermode
   if 0 < l.annotations.len:
     fields["annotations"] = % l.annotations
+  if not l.plotBgColor.empty:
+    fields["plot_bgcolor"] = % l.plotBgColor
+  if not l.paperBgColor.empty:
+    fields["paper_bgcolor"] = % l.paperBgColor
 
   result = JsonNode(kind: JObject, fields: fields)
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -112,7 +112,7 @@ func `%`*(f: Font): JsonNode =
     fields["color"] = % f.color
   if f.family.len > 0:
     fields["family"] = % f.family
-  result = JsonNode(kind: Jobject, fields: fields)
+  result = JsonNode(kind: JObject, fields: fields)
 
 func `%`*(a: Axis): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
@@ -138,12 +138,13 @@ func `%`*(a: Axis): JsonNode =
   if a.rangeslider != nil:
     fields["rangeslider"] = % a.rangeslider
 
-  result = JsonNode(kind:Jobject, fields: fields)
+
+  result = JsonNode(kind: JObject, fields: fields)
 
 func `%`*(l: Layout): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if l == nil:
-    return JsonNode(kind: Jobject, fields: fields)
+    return JsonNode(kind: JObject, fields: fields)
   if l.title != "":
     fields["title"] = % l.title
   if l.width != 0:
@@ -164,7 +165,8 @@ func `%`*(l: Layout): JsonNode =
     fields["hovermode"] = % l.hovermode
   if 0 < l.annotations.len:
     fields["annotations"] = % l.annotations
-  result = JsonNode(kind: Jobject, fields: fields)
+
+  result = JsonNode(kind: JObject, fields: fields)
 
 func `%`*(a: Annotation): JsonNode =
   ## creates a JsonNode from an `Annotations` object depending on the object variant
@@ -293,7 +295,7 @@ func `%`*(t: Trace): JsonNode =
   if t.marker != nil:
     fields["marker"] = % t.marker
 
-  result = JsonNode(kind: Jobject, fields: fields)
+  result = JsonNode(kind: JObject, fields: fields)
 
 func `%`*(m: Marker): JsonNode =
   var fields = initOrderedTable[string, JsonNode](8)
@@ -304,15 +306,15 @@ func `%`*(m: Marker): JsonNode =
       fields["size"] = % m.size
   if m.color.len > 0:
     if m.color.len == 1:
-      fields["color"] = % m.color[0].toHtmlHex()
+      fields["color"] = % m.color[0]
     else:
-      fields["color"] = % m.color.toHtmlHex()
+      fields["color"] = % m.color
   elif m.colorVals.len > 0:
     fields["color"] = % m.colorVals
     fields["colorscale"] = % m.colormap
     fields["showscale"] = % true
 
-  result = JsonNode(kind: Jobject, fields: fields)
+  result = JsonNode(kind: JObject, fields: fields)
 
 func `$`*(d: Trace): string =
   var j = % d

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -149,12 +149,12 @@ func `%`*(l: Legend): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if l.font != nil:
     fields["font"] = % l.font
-  if not l.bgcolor.empty:
-    fields["bgcolor"] = % l.bgcolor
+  if not l.backgroundColor.empty:
+    fields["bgcolor"] = % l.backgroundColor
   if not l.bordercolor.empty:
-    fields["bordercolor"] = % l.bordercolor
+    fields["bordercolor"] = % l.borderColor
   if l.borderwidth != 0:
-    fields["borderwidth"] = % l.borderwidth
+    fields["borderwidth"] = % l.borderWidth
   case l.orientation
   of Orientation.Vertical, Orientation.Horizontal:
     fields["orientation"] = % l.orientation

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -141,6 +141,27 @@ func `%`*(a: Axis): JsonNode =
 
   result = JsonNode(kind: JObject, fields: fields)
 
+func `%`*(l: Legend): JsonNode =
+  var fields = initOrderedTable[string, JsonNode](4)
+  if l.font != nil:
+    fields["font"] = % l.font
+  if not l.bgcolor.empty:
+    fields["bgcolor"] = % l.bgcolor
+  if not l.bordercolor.empty:
+    fields["bordercolor"] = % l.bordercolor
+  if l.borderwidth != 0:
+    fields["borderwidth"] = % l.borderwidth
+  case l.orientation
+  of Orientation.Vertical, Orientation.Horizontal:
+    fields["orientation"] = % l.orientation
+  else: discard
+  # fields for x and y are used always. Zero initialized means that if no
+  # x, y given, but colors / width set, location will be at x / y == 0 / 0
+  # alternative would be to check for != 0 on both, which would disallow 0 / 0!
+  fields["x"] = % l.x
+  fields["y"] = % l.y
+  result = JsonNode(kind: JObject, fields: fields)
+
 func `%`*(l: Layout): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if l == nil:
@@ -159,6 +180,9 @@ func `%`*(l: Layout): JsonNode =
     fields["yaxis2"] = % l.yaxis2
   if $l.barmode != "":
     fields["barmode"] = % l.barmode
+  if l.legend != nil:
+    fields["legend"] = % l.legend
+    fields["showlegend"] = % l.showlegend
   # default to closest because other modes suck.
   fields["hovermode"] = % "closest"
   if $l.hovermode != "":

--- a/src/plotly/color.nim
+++ b/src/plotly/color.nim
@@ -7,8 +7,9 @@ func empty*(): Color =
   result = Color(r: 0, g: 0, b: 0, a: 0)
 
 func empty*(c: Color): bool =
+  ## checks whether given color is black according to above
   # TODO: this is also black, but should never need black with alpha == 0
-  result = c.r == 0 and c.g == 0 and c.b == 0 and c.a == 0
+  result = c == empty()
 
 func toHtmlHex*(colors: seq[Color]): seq[string] =
   result = newSeq[string](len(colors))

--- a/src/plotly/plotly_sugar.nim
+++ b/src/plotly/plotly_sugar.nim
@@ -235,6 +235,7 @@ proc binRange*[T](plt: Plot[T], start, stop: float, idx = 0): Plot[T] =
 proc legend*[T](plt: Plot[T], legend: Legend): Plot[T] =
   result = plt
   result.layout.legend = legend
+  result.layout.showLegend = true
 
 proc legendLocation*[T](plt: Plot[T], x, y: float): Plot[T] =
   result = plt

--- a/src/plotly/plotly_sugar.nim
+++ b/src/plotly/plotly_sugar.nim
@@ -41,6 +41,11 @@ template barPlot*(x, y: untyped): untyped =
   let plt = Plot[yType](traces: @[tr], layout: plLayout)
   plt
 
+proc histTrace*[T](hist: seq[T]): Trace[T] =
+  type hType = type(hist[0])
+  result = Trace[hType](`type`: PlotType.Histogram,
+                        xs: hist)
+
 template histPlot*(hist: untyped): untyped =
   type hType = type(hist[0])
   let title = "Histogram of " & astToStr(hist)
@@ -49,8 +54,7 @@ template histPlot*(hist: untyped): untyped =
                         xaxis: Axis(title: astToStr(x)),
                         yaxis: Axis(title: "Counts"),
                         autosize: false)
-  let tr = Trace[hType](`type`: PlotType.Histogram,
-                        xs: hist)
+  let tr = histTrace(hist)
   var plt = Plot[hType](traces: @[tr], layout: plLayout)
   plt
 
@@ -77,6 +81,12 @@ template heatmap*(x, y, z: untyped): untyped =
   var plt = Plot[xType](traces: @[tr], layout: plLayout)
   plt
 
+proc heatmapTrace*[T](z: seq[seq[T]]): Trace[T] =
+  type hType = type(z[0])
+  result = Trace[hType](`type`: PlotType.Heatmap,
+                        colorMap: ColorMap.Viridis,
+                        xs: hist)
+
 template heatmap*[T](z: seq[seq[T]]): untyped =
   type zType = type(z[0][0])
   var zs = z
@@ -92,23 +102,26 @@ template heatmap*[T](z: seq[seq[T]]): untyped =
   var plt = Plot[zType](traces: @[tr], layout: plLayout)
   plt
 
-
-template scatterPlot*(x, y: untyped): untyped =
+proc scatterTrace*[T, U](x: seq[T], y: seq[U]): Trace[T] =
   type xType = type(x[0])
   let xData = x
   # make sure y has same dtype
   let yData = y.mapIt(xType(it))
+  result = Trace[xType](mode: PlotMode.Markers,
+                        marker: Marker[xType](),
+                        `type`: PlotType.Scatter,
+                        xs: xData,
+                        ys: yData)
+
+template scatterPlot*(x, y: untyped): untyped =
+  type xType = type(x[0])
   let title = "Scatter plot of " & astToStr(x) & " vs. " & astToStr(y)
   let plLayout = Layout(title: title,
                         width: 800, height: 600,
                         xaxis: Axis(title: astToStr(x)),
                         yaxis: Axis(title: astToStr(y)),
                         autosize: false)
-  let tr = Trace[xType](mode: PlotMode.Markers,
-                        marker: Marker[xType](),
-                        `type`: PlotType.Scatter,
-                        xs: xData,
-                        ys: yData)
+  let tr = scatterTrace(x, y)
   var plt = Plot[xType](traces: @[tr], layout: plLayout)
   plt
 
@@ -125,6 +138,10 @@ template scatterColor*(x, y, z: untyped): untyped =
     .markercolor(colors = zData,
                  map = ColorMap.Viridis)
   plt
+
+proc addTrace*[T](plt: Plot[T], t: Trace[T]): Plot[T] =
+  result = plt
+  result.traces.add t
 
 proc title*[T](plt: Plot[T], t: string): Plot[T] =
   result = plt

--- a/src/plotly/plotly_sugar.nim
+++ b/src/plotly/plotly_sugar.nim
@@ -149,7 +149,7 @@ proc title*[T](plt: Plot[T], t: string): Plot[T] =
 
 proc width*[T, U: SomeNumber](plt: Plot[T], width: U): Plot[T] =
   result = plt
-  result.layout.width = U.roundOrIdent.int
+  result.layout.width = width.roundOrIdent.int
 
 proc height*[T, U: SomeNumber](plt: Plot[T], height: U): Plot[T] =
   result = plt

--- a/src/plotly/plotly_sugar.nim
+++ b/src/plotly/plotly_sugar.nim
@@ -184,6 +184,8 @@ proc markerSize*[T, U: SomeNumber](plt: Plot[T], val: U, idx = 0): Plot[T] =
 template pltLabel*(plt: untyped,
                    axis: untyped,
                    label: string): untyped =
+  if plt.layout.axis == nil:
+    plt.layout.axis = Axis()
   plt.layout.axis.title = label
 
 proc xlabel*[T](plt: Plot[T], label: string): Plot[T] =
@@ -208,3 +210,76 @@ proc binRange*[T](plt: Plot[T], start, stop: float, idx = 0): Plot[T] =
   result = plt
   doAssert result.traces[idx].`type` == PlotType.Histogram
   result.traces[idx].bins = (start, stop)
+
+proc legend*[T](plt: Plot[T], legend: Legend): Plot[T] =
+  result = plt
+  result.layout.legend = legend
+
+proc legendLocation*[T](plt: Plot[T], x, y: float): Plot[T] =
+  result = plt
+  if result.layout.legend == nil:
+    result.layout.legend = Legend()
+  result.layout.legend.x = x
+  result.layout.legend.y = y
+
+proc legendBgColor*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  if result.layout.legend == nil:
+    result.layout.legend = Legend()
+  result.layout.legend.bgcolor = color
+
+proc legendBorderColor*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  if result.layout.legend == nil:
+    result.layout.legend = Legend()
+  result.layout.legend.borderColor = color
+
+proc legendBorderWidth*[T](plt: Plot[T], width: int): Plot[T] =
+  result = plt
+  if result.layout.legend == nil:
+    result.layout.legend = Legend()
+  result.layout.legend.borderWidth = width
+
+proc legendOrientation*[T](plt: Plot[T], orientation: Orientation): Plot[T] =
+  result = plt
+  if result.layout.legend == nil:
+    result.layout.legend = Legend()
+  result.layout.legend.orientation = orientation
+
+proc gridWidthX*[T](plt: Plot[T], width: int): Plot[T] =
+  result = plt
+  if result.layout.xaxis == nil:
+    result.layout.xaxis = Axis()
+  result.layout.xaxis.gridWidth = width
+
+proc gridWidthY*[T](plt: Plot[T], width: int): Plot[T] =
+  result = plt
+  if result.layout.xaxis == nil:
+    result.layout.xaxis = Axis()
+  result.layout.yaxis.gridWidth = width
+
+proc gridWidth*[T](plt: Plot[T], width: int): Plot[T] =
+  result = plt.gridWidthX(width).gridWidthY(width)
+
+proc gridColorX*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  if result.layout.xaxis == nil:
+    result.layout.xaxis = Axis()
+  result.layout.xaxis.gridColor = color
+
+proc gridColorY*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  if result.layout.xaxis == nil:
+    result.layout.xaxis = Axis()
+  result.layout.yaxis.gridColor = color
+
+proc gridColor*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt.gridColorX(color).gridColorY(color)
+
+proc backgroundColor*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  result.layout.backgroundColor = color
+
+proc paperColor*[T](plt: Plot[T], color: Color): Plot[T] =
+  result = plt
+  result.layout.paperColor = color

--- a/src/plotly/plotly_sugar.nim
+++ b/src/plotly/plotly_sugar.nim
@@ -196,6 +196,10 @@ proc ylabel*[T](plt: Plot[T], label: string): Plot[T] =
   result = plt
   result.pltLabel(yaxis, label)
 
+proc name*[T](plt: Plot[T], name: string, idx = 0): Plot[T] =
+  result = plt
+  result.traces[idx].name = name
+
 proc nbins*[T](plt: Plot[T], nbins: int, idx = 0): Plot[T] =
   result = plt
   doAssert result.traces[idx].`type` == PlotType.Histogram

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -216,6 +216,16 @@ type
     text*: string
     showarrow*: bool
 
+  Legend* = ref object
+    # location in x, y in relative coordinategs of the layout in [-2, 3]
+    x*: float
+    y*: float
+    font*: Font
+    bgcolor*: Color
+    bordercolor*: Color
+    borderwidth*: int # border width in pixels
+    orientation*: Orientation
+
   Layout* = ref object
     title*: string
     width*: int
@@ -224,6 +234,7 @@ type
     annotations*: seq[Annotation]
     autosize*: bool
     showlegend*: bool
+    legend*: Legend
     xaxis*: Axis
     yaxis*: Axis
     yaxis2*: Axis

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -241,3 +241,5 @@ type
     yaxis*: Axis
     yaxis2*: Axis
     barmode*: BarMode
+    plotBgColor*: Color # background of plot
+    paperBgColor*: Color # background of paper / canvas

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -207,6 +207,8 @@ type
     range*: tuple[start, stop: float]
     # oposite of showticklabels
     hideticklabels*: bool
+    gridColor*: Color
+    gridWidth*: int
 
   Annotation* = ref object
     x*: float

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -219,13 +219,13 @@ type
     showarrow*: bool
 
   Legend* = ref object
-    # location in x, y in relative coordinategs of the layout in [-2, 3]
+    # location in x, y in relative coordinates of the layout in [-2, 3]
     x*: float
     y*: float
     font*: Font
-    bgcolor*: Color
-    bordercolor*: Color
-    borderwidth*: int # border width in pixels
+    backgroundColor*: Color
+    borderColor*: Color
+    borderWidth*: int # border width in pixels
     orientation*: Orientation
 
   Layout* = ref object

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -241,5 +241,5 @@ type
     yaxis*: Axis
     yaxis2*: Axis
     barmode*: BarMode
-    plotBgColor*: Color # background of plot
-    paperBgColor*: Color # background of paper / canvas
+    backgroundColor*: Color # background of plot
+    paperColor*: Color # background of paper / canvas


### PR DESCRIPTION
This PR does the following:
- adds a Legend object to place the legend of a plot freely, as well as customize its color
- adds field to change width and color of grid lines
- adds field to change background of a plot or the whole plotly frame
- changes `%(c: Color)` to return a `JsonNode` instead of a string
- fixes setting of font colors (previously set font iff color was black)
- fixes a bug in `width` sugar proc
- adds a whole bunch of sugar procs for the above and to simplify creation of some traces

Regarding the sugar module: if you think this is getting out of hand, I could make this a separate nimble module. I just think as long as anyone can come up with a better idea, this (while being a lot of "duplicate" code) is still the best way for a more streamlined usage. :/ 