### PR TITLE
Add subplot macro for basic subplots

### DIFF
--- a/examples/fig18_subplots.nim
+++ b/examples/fig18_subplots.nim
@@ -68,3 +68,16 @@ let pltCombined = subplots:
     right = 1.0
     top = 0.3
 pltCombined.show()
+
+let pltC2 = subplots:
+  baseLayout: baseLayout
+  grid:
+    rows: 3
+    columns: 1
+  plot:
+    plt1
+  plot:
+    plt2
+  plot:
+    plt3
+pltC2.show()

--- a/examples/fig18_subplots.nim
+++ b/examples/fig18_subplots.nim
@@ -4,7 +4,7 @@ import math
 import chroma
 import strformat
 
-
+# given some data
 const
   n = 5
 var
@@ -24,12 +24,9 @@ for i in 0 .. y.high:
   y3[i] = -(i * 5)
   sizes[i] = float64(10 + (i mod 10))
 
+# and with it defined plots of possibly different datatypes (note `float` and `int`)
 let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
-                       xs: x, ys: y,
-                       marker: Marker[float64](size: sizes,
-                                               colorVals: y,
-                                               colorMap: ColorMap.Viridis))
-
+                       xs: x, ys: y)
 let d2 = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
                     xs: x2, ys: y2)
 let d3 = Trace[float](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
@@ -45,33 +42,56 @@ let baseLayout = Layout(title: "A bunch of subplots!", width: 800, height: 800,
                         xaxis: Axis(title: "linear x"),
                         yaxis: Axis(title: "y also linear"), autosize: false)
 
-
 let plt1 = Plot[float64](layout: layout, traces: @[d, d3])
 let plt2 = Plot[int](layout: baseLayout, traces: @[d2, d4])
 let plt3 = scatterPlot(x3, y3).title("Another plot!").width(1000)
 
+# we wish to create a subplot including all three plots. The `subplots` macro
+# returns a special `PlotJson` object, which stores the same information as
+# a `Plot[T]` object, but already converted to `JsonNodes`. This is done for easier
+# handling of different data types. But fear not, this object is given straight to
+# `show` or `saveImage` unless you wish to manually add something to the `JsonNodes`.
 let pltCombined = subplots:
+  # first we need to define a base layout for our plot, which defines size
+  # of canvas and other applicable properties
   baseLayout: baseLayout
+  # now we define all plots in `plot` blocks
   plot:
+    # the first identifier points to a `Plot[T]` object
     plt1
+    # it follows the description of the `Domain`, i.e. the location and
+    # size of the subplot. This can be done explicitly as follows:
+    # Note that the order of the fields is not important, but you need to
+    # define all 4!
     left: 0.0
     bottom: 0.0
-    right: 0.45
-    top: 1.0
+    width: 0.45
+    height: 1.0
   plot:
     plt2
+    # alternatively a nameless tuple conforming to the order
     (0.6, 0.5, 0.4, 0.5)
   plot:
     plt3
+    # or instead of defining via `:`, you can use `=`
     left = 0.7
     bottom = 0.0
+    # and also replace `widht` and `height` by the right and top edge of the plot
+    # NOTE: you *cannot* mix e.g. right with height!
     right = 1.0
     top = 0.3
 pltCombined.show()
 
+# if you do not wish to define domains for each plot, you also simply define
+# grid as we do here
 let pltC2 = subplots:
   baseLayout: baseLayout
+  # this requires the `grid` block
   grid:
+    # it may contain a `rows` and `column` field, although both are optional
+    # If only one is set, the other will be set to 1. If neither is set,
+    # nor any domains on the plots, a grid will be calculated automatically,
+    # favoring more columns than rows.
     rows: 3
     columns: 1
   plot:

--- a/examples/fig18_subplots.nim
+++ b/examples/fig18_subplots.nim
@@ -1,0 +1,70 @@
+import plotly, sequtils, macros, algorithm
+import json
+import math
+import chroma
+import strformat
+
+
+const
+  n = 5
+var
+  y = new_seq[float64](n)
+  x = new_seq[float64](n)
+  x2 = newSeq[int](n)
+  y2 = newSeq[int](n)
+  x3 = newSeq[int](n)
+  y3 = newSeq[int](n)
+  sizes = new_seq[float64](n)
+for i in 0 .. y.high:
+  x[i] = i.float
+  y[i] = sin(i.float)
+  x2[i] = i
+  y2[i] = i * 5
+  x3[i] = i
+  y3[i] = -(i * 5)
+  sizes[i] = float64(10 + (i mod 10))
+
+let d = Trace[float64](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                       xs: x, ys: y,
+                       marker: Marker[float64](size: sizes,
+                                               colorVals: y,
+                                               colorMap: ColorMap.Viridis))
+
+let d2 = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                    xs: x2, ys: y2)
+let d3 = Trace[float](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                      xs: x2.mapIt(it.float), ys: y2.mapIt(it.float))
+let d4 = Trace[int](mode: PlotMode.LinesMarkers, `type`: PlotType.ScatterGL,
+                      xs: x3, ys: y3)
+
+let layout = Layout(title: "saw the sin, colors of sin value!", width: 1000, height: 400,
+                    xaxis: Axis(title: "my x-axis"),
+                    yaxis: Axis(title: "y-axis too"), autosize: false)
+
+let baseLayout = Layout(title: "A bunch of subplots!", width: 800, height: 800,
+                        xaxis: Axis(title: "linear x"),
+                        yaxis: Axis(title: "y also linear"), autosize: false)
+
+
+let plt1 = Plot[float64](layout: layout, traces: @[d, d3])
+let plt2 = Plot[int](layout: baseLayout, traces: @[d2, d4])
+let plt3 = scatterPlot(x3, y3).title("Another plot!").width(1000)
+
+let pltCombined = subplots:
+  baseLayout: baseLayout
+  plot:
+    plt1
+    left: 0.0
+    bottom: 0.0
+    right: 0.45
+    top: 1.0
+  plot:
+    plt2
+    (0.6, 0.5, 0.4, 0.5)
+  plot:
+    plt3
+    left = 0.7
+    bottom = 0.0
+    right = 1.0
+    top = 0.3
+pltCombined.show()

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -5,14 +5,12 @@ import sequtils
 
 # we now import the plotly modules and export them so that
 # the user sees them as a single module
-import plotly/api
+import plotly / [api, plotly_types, errorbar, plotly_sugar, plotly_subplots]
 export api
-import plotly/plotly_types
 export plotly_types
-import plotly/errorbar
 export errorbar
-import plotly/plotly_sugar
 export plotly_sugar
+export plotly_subplots
 
 when defined(webview):
   import webview

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -229,6 +229,9 @@ func `%`*(t: Trace): JsonNode =
   if t.ys.len > 0:
     fields["y"] = % t.ys
 
+  if t.xaxis != "":
+    fields["xaxis"] = % t.xaxis
+
   if t.yaxis != "":
     fields["yaxis"] = % t.yaxis
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -9,6 +9,12 @@ import plotly_types
 import color
 import errorbar
 
+proc toPlotJson*[T](plt: Plot[T]): PlotJson =
+  ## converts a given `Plot[T]` object to a `PlotJson` object
+  result = new PlotJson
+  result.traces = % plt.traces
+  result.layout = % plt.layout
+
 func parseHistogramFields[T](fields: var OrderedTable[string, JsonNode], t: Trace[T]) =
   ## parse the fields of the histogram type. Usese a separate proc
   ## for clarity.

--- a/src/plotly/plotly_subplots.nim
+++ b/src/plotly/plotly_subplots.nim
@@ -10,11 +10,12 @@ type
     columns: int
 
 proc convertDomain*(d: Domain | DomainAlt): Domain =
-  ## proc to convert a domain tuple from
+  ## proc to get a `Domain` from either a `Domain` or `DomainAlt` tuple.
+  ## That is a tuple of:
   ## left, bottom, right, top
-  ## notation to
+  ## notation to:
   ## left, bottom, width, height
-  when type(d) is tuple[left, bottom, width, height: float]:
+  when type(d) is Domain:
     result = d
   else:
     result = (left: d.left,

--- a/src/plotly/plotly_subplots.nim
+++ b/src/plotly/plotly_subplots.nim
@@ -1,4 +1,7 @@
-proc convertDomain(d: Domain | DomainAlt): Domain =
+import json, macros
+import plotly_types, plotly_sugar, api
+
+proc convertDomain*(d: Domain | DomainAlt): Domain =
   ## proc to convert a domain tuple from
   ## left, bottom, right, top
   ## notation to
@@ -107,9 +110,9 @@ proc handlePlotStmt(plt: NimNode): (NimNode, NimNode) =
       # is nameless tuple
       doAssert plt[i].len == 4, "Domain needs to consist of 4 elements!"
       domain.add handleDomain(ident"left", plt[i][0])
-      domain.add handleDomain(ident"bottom", plt[i][0])
-      domain.add handleDomain(ident"width", plt[i][0])
-      domain.add handleDomain(ident"height", plt[i][0])
+      domain.add handleDomain(ident"bottom", plt[i][1])
+      domain.add handleDomain(ident"width", plt[i][2])
+      domain.add handleDomain(ident"height", plt[i][3])
       # ignore what comes after
       break
     of nnkCall:
@@ -155,6 +158,11 @@ macro subplots*(stmts: untyped): untyped =
   ##
   ## will create a subplot of `plt1` on the left and `plt2` on the
   ## right.
+  ## This simply creates the following call to `combine`.
+  ## let subplt = combine(layout,
+  ##                      [plt1.toPlotJson, plt2.toPlotJson],
+  ##                      [(left: 0.0, bottom: 0.0, width: 0.45, height: 1.0),
+  ##                       (left: 0.55, bottom: 0.0, width: 0.45, height: 1.0)])
   var
     layout: NimNode
     # plots contain `Plot[T]` identifier and `domain`

--- a/src/plotly/plotly_subplots.nim
+++ b/src/plotly/plotly_subplots.nim
@@ -309,12 +309,10 @@ macro subplots*(stmts: untyped): untyped =
         `domainIdent`.convertDomain
 
   # call combine proc
-  echo grid.repr
   result = quote do:
     block:
       `grid`
       combine(`layout`, `pltArray`, `domainArray`, `gridIdent`)
-  echo result.repr
 
 when isMainModule:
   # test the calculation of rows and columns

--- a/src/plotly/plotly_subplots.nim
+++ b/src/plotly/plotly_subplots.nim
@@ -1,0 +1,190 @@
+proc convertDomain(d: Domain | DomainAlt): Domain =
+  ## proc to convert a domain tuple from
+  ## left, bottom, right, top
+  ## notation to
+  ## left, bottom, width, height
+  when type(d) is tuple[left, bottom, width, height: float]:
+    result = d
+  else:
+    result = (left: d.left,
+              bottom: d.bottom,
+              width: d.right - d.left,
+              height: d.top - d.bottom)
+
+proc combine(baseLayout: Layout,
+             plts: openArray[PlotJson],
+             domains: openArray[Domain]): PlotJson =
+  # we need to combine the plots on a JsonNode level to avoid problems with
+  # different plot types!
+  var res = newPlot()
+  result = res.toPlotJson
+  result.layout = % baseLayout
+  doAssert plts.len == domains.len, "Every plot needs a domain!"
+  for i, p in plts:
+    #doAssert p.traces.len == 1
+    let trIdx = result.traces.len
+    # first add traces of `*each Plot*`, only afterwards flatten them!
+    result.traces.add p.traces
+    let domain = domains[i]
+    # first plot needs to be treated differently than all others
+    let idx = result.traces.len
+    var
+      xaxisStr = "xaxis"
+      yaxisStr = "yaxis"
+    if i > 0:
+      xaxisStr &= $idx
+      yaxisStr &= $idx
+
+    result.layout[xaxisStr] = p.layout["xaxis"]
+    result.layout[yaxisStr] = p.layout["yaxis"]
+    let xdomain = @[domain.left, domain.left + domain.width]
+    let ydomain = @[domain.bottom, domain.bottom + domain.height]
+    result.layout[xaxisStr]["domain"] = % xdomain
+    result.layout[yaxisStr]["domain"] = % ydomain
+
+    if i > 0:
+      # anchor xaxis to y data and vice versa
+      result.layout[xaxisStr]["anchor"] = % ("y" & $idx)
+      result.layout[yaxisStr]["anchor"] = % ("x" & $idx)
+
+  var i = 0
+  # flatten traces and set correct axis for correct original plots
+  var traces = newJArray()
+  for tr in mitems(result.traces):
+    if i > 0:
+      for t in tr:
+        t["xaxis"] = % ("x" & $(i + 1))
+        t["yaxis"] = % ("y" & $(i + 1))
+        traces.add t
+    else:
+      for t in tr:
+        traces.add t
+    inc i
+  result.traces = traces
+
+proc handleDomain(field, value: NimNode): NimNode =
+  ## receives a field of the domain description and the corresponding
+  ## element and returns an element for a named tuple of the domain for the plot
+  case field.strVal
+  of "left", "l":
+    result = nnkExprColonExpr.newTree(ident"left", value)
+  of "right", "r":
+    result = nnkExprColonExpr.newTree(ident"right", value)
+  of "bottom", "b":
+    result = nnkExprColonExpr.newTree(ident"bottom", value)
+  of "top", "t":
+    result = nnkExprColonExpr.newTree(ident"top", value)
+  of "width", "w":
+    result = nnkExprColonExpr.newTree(ident"width", value)
+  of "height", "h":
+    result = nnkExprColonExpr.newTree(ident"height", value)
+  else:
+    error("Plot domain needs to be described by:\n" &
+      "\t{`left`, `right`, `bottom`, `top`, `width`, `height`}\n" &
+      "Field: " & field.repr & ", Value: " & value.repr)
+
+proc handlePlotStmt(plt: NimNode): (NimNode, NimNode) =
+  ## handle Plot description.
+  ## First line needs to be identifier of the `Plot[T]` object
+  ## Second line either a (nameless) tuple of
+  ## (left: float, bottom: float, width: float, height: float)
+  ## or several lines with either of the following keys:
+  ## left = left end of this plot
+  ## bottom = bottom end of this plot
+  ## and:
+  ## width = width of this plot
+  ## height = width of this plot
+  ## ``or``:
+  ## right = right end of this plot
+  ## top = top end of this plot
+  ## These can either be done as an assignment, i.e. via `=` or
+  ## as a call, i.e. via `:`
+  result[0] = plt[0]
+  var domain = newNimNode(kind = nnkPar)
+  for i in 1 ..< plt.len:
+    case plt[i].kind
+    of nnkPar:
+      # is nameless tuple
+      doAssert plt[i].len == 4, "Domain needs to consist of 4 elements!"
+      domain.add handleDomain(ident"left", plt[i][0])
+      domain.add handleDomain(ident"bottom", plt[i][0])
+      domain.add handleDomain(ident"width", plt[i][0])
+      domain.add handleDomain(ident"height", plt[i][0])
+      # ignore what comes after
+      break
+    of nnkCall:
+      # for call RHS is StmtList
+      domain.add handleDomain(plt[i][0], plt[i][1][0])
+    of nnkAsgn:
+      # for assignment RHS is single expr
+      domain.add handleDomain(plt[i][0], plt[i][1])
+    else:
+        error("Plot statement needs to consist of Plot ident, nnkCall or " &
+          "nnkAsgn. Line is " & plt[i].repr & " of kind " & $plt[i].kind)
+    if domain.len == 4:
+      # have a full domain, stop
+      break
+
+  result[1] = domain
+
+macro subplots*(stmts: untyped): untyped =
+  ## macro to create subplots from several `Plot[T]` objects
+  ## the macro needs to contain the blocks `baseLayout`
+  ## and one or more `plot` blocks. A plot block has the
+  ## `Plot[T]` object in line 1, followed by the domain description
+  ## of the subplot, i.e. the location within the whole canvas.
+  ##
+  ## .. code-block:: nim
+  ## let plt1 = scatterPlot(x, y) # x, y some seq[T]
+  ## let plt2 = scatterPlot(x2, y2) # x2, y2 some other seq[T]
+  ## let layout = Layout(...) # some layout for the whole canvas
+  ## let subplt = subplots:
+  ##   baseLayout: layout
+  ##   plot:
+  ##     plt1
+  ##     left: 0.0
+  ##     bottom: 0.0
+  ##     width: 0.45
+  ##     height: 1.0
+  ##     # alternatively use right, top instead of width, height
+  ##     # single letters also supported, e.g. l == left
+  ##   plot:
+  ##     plt2
+  ##     # or just write a concise tuple, here the
+  ##     (0.55, 0.0, 0.45, 1.0)
+  ##
+  ## will create a subplot of `plt1` on the left and `plt2` on the
+  ## right.
+  var
+    layout: NimNode
+    # plots contain `Plot[T]` identifier and `domain`
+    plots: seq[(NimNode, NimNode)]
+  for stmt in stmts:
+    case stmt.kind
+    of nnkCall:
+      case stmt[0].strVal
+      of "baseLayout":
+        layout = stmt[1][0]
+      of "plot":
+        # only interested in content of `plot:`, hence [1]
+        plots.add handlePlotStmt(stmt[1])
+    else:
+      error("Statement needs to be `baseLayout` or `plot`! " &
+        "Line `" & stmt.repr & "` is " & $stmt.kind)
+
+  var
+    pltArray = nnkBracket.newTree()
+    domainArray = nnkBracket.newTree()
+  # split the plot tuples and apply conversions
+  # `Plot` -> `PlotJson`
+  # `DomainAlt` | `Domain` -> `Domain`
+  for i, plt in plots:
+    let pltIdent = plt[0]
+    let domainIdent = plt[1]
+    pltArray.add quote do:
+      `pltIdent`.toPlotJson
+    domainArray.add quote do:
+      `domainIdent`.convertDomain
+  # call combine proc
+  result = quote do:
+    combine(`layout`, `pltArray`, `domainArray`)

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -204,6 +204,13 @@ type
   RangeSlider* = ref object
     visible*: bool
 
+  # tuple types to set location of subplots within a plot
+  # given in relative coordinates of the plot [0, 1] canvas
+  Domain* = tuple
+    left, bottom, width, height: float
+  DomainAlt* = tuple
+    left, bottom, right, top: float
+
   Axis* = ref object
     title*: string
     font*: Font

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -1,4 +1,4 @@
-import chroma
+import chroma, json
 
 # this module contains all types used in the plotly module
 

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -208,6 +208,8 @@ type
   # given in relative coordinates of the plot [0, 1] canvas
   Domain* = tuple
     left, bottom, width, height: float
+  # alternative notation for a `Domain`. Instead of using width and height,
+  # directly set right and top edge of plot.
   DomainAlt* = tuple
     left, bottom, right, top: float
 

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -7,6 +7,12 @@ type
     traces* : seq[Trace[T]]
     layout*: Layout
 
+  PlotJson* = ref object
+    traces* : JsonNode
+    layout*: JsonNode
+
+  SomePlot* = Plot | PlotJson
+
   PlotType* {.pure.} = enum
     Scatter = "scatter"
     ScatterGL = "scattergl"

--- a/src/plotly/plotly_types.nim
+++ b/src/plotly/plotly_types.nim
@@ -151,6 +151,7 @@ type
     mode*: PlotMode
     fill*: PlotFill
     name*: string
+    xaxis*: string
     yaxis*: string
     # case on `type`, since we only need ColorMap for
     # PlotType.HeatMap


### PR DESCRIPTION
This adds basic subplot support via the new `subplots` macro. 

A basic implementation for that was quite easy, but then I realized that for real subplots it might be justified to have `Plot[T]` objects as a basis with different `T`. Therefore I introduced a `PlotJson` object, which is basically the `Plot[T]` object albeit with the two fields already converted to `JsonNodes`. This way we can merge the two `Plot[T]` of potentially different data types together. 
The main part of the creation of subplots is then the (currently pretty static and hacky) `combine` proc. Since the signature of `combine` isn't very nice and in my opinion the user doesn't need to know what's needed to create a subplot, I started to write a macro. In the end it's a lot of lines for a single output line of the macro, but well. It's there now. :P 
Usage looks like this (assuming we have a `plt1: Plot[T]`, `plt2: Plot[U]`, `layout: Layout`):
```nim
let subplt = subplots:
  baseLayout: layout
  plot:
    plt1
    left: 0.0
    bottom: 0.0
    width: 0.45
    height: 1.0
    # alternatively use right, top instead of width, height
    # single letters also supported, e.g. l == left
  plot:
    plt2
    # or just write a concise tuple, here the
    (0.55, 0.0, 0.45, 1.0)
```
So it consists of a layout object to be used as the base layout for the whole plot and then several `plot` blocks. Each `plot` block then just takes a `Plot[T]` as the first line and then a description of the plot location. Either as a nameless tuple of the type:
`(left, bottom, width, height)` 
in relative coordinates of the canvas in `[0, 1]`. Or one can specifically set each of the fields, one per line. That way one may also use `right`, `top` instead of `width`, `height` (for good measure instead of `:`, `=` is also supported, and so are just first letters for each location, i.e. `l`, `b`, ...). 

#### Useful sideffect of `PlotJson`
As a side effect, since `PlotJson` is now a valid type for `show` and `saveImage` one can thus easily extend plotly "on the fly" if a feature isn't available. So for instance if we have some 
```nim
let plt: Plot[T] = getSomePlot()
```
and we wish to use a feature that's not in nim-plotly: for example to set the length of the ticks. In plotly this is done via `ticklen` (https://plot.ly/javascript/reference/#layout-yaxis-ticklen). Now we can just do:
```nim
let pltJson = plt.toPlotJson
pltJson["xaxis"]["ticklen"] = 10 # twice as long as default
pltJson.show()
```
and all should work.
In theory one can also just copy paste some plotly.js code and create a `JsonNode` via the `%*` macro and with little change one can even create a plot that way. If this https://github.com/nim-lang/Nim/pull/10037 PR would be merged that would become almost trivial. 
Not very useful in general, but for quick prototyping of unavailable features might come in handy.