### PR TITLE
[do not merge] dummy commit that shows CI doesn't check validity of html files

### DIFF
--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -9,7 +9,7 @@ const defaultTmplString = """
 	<body>
 		<div id="plot0"></div>
 		<script>
-			Plotly.newPlot('plot0', $data, $layout)
+			Plotly.newPlot('plot1', $data, $layout)
                 </script>
                 $saveImage
 	</body>


### PR DESCRIPTION
i had the suspicion so I created this PR.. turns out I was right, CI doesn't check validity of html files

running this locally you'll see a black window, dev console on chrome says:
```
Uncaught Error: No DOM element with id 'plot1' exists on the page.
    at Object.e.exports [as getGraphDiv] (plotly-latest.min.js:7)
    at Object.r.newPlot (plotly-latest.min.js:7)
    at x.html:11
```

but CI is green https://travis-ci.com/timotheecour/nim-plotly/builds/98718821

so we need something smarter to avoid regressions.
doesn't have to be 100% correct, but right now it doesn't check anything beyond nim code being valid :)
I don't know much about this topic, here's off top of my head:

## approach 1: html-proofer (dead end IMO)
* https://github.com/gjtorikian/html-proofer : Test your rendered HTML files to make sure they're accurate.

```
export GEM_HOME=$HOME/.gem
gem install html-proofer
$GEM_HOME/bin/htmlproofer --check-html /tmp/nimplotly/D20190125T182937.html
```
disappointing: doesn't catch lots of errors when i insert them (catches some, but IMO it's not suitable, unless there's some magic options i haven't seen)
```
Running ["ImageCheck", "LinkCheck", "ScriptCheck"] on /tmp/nimplotly/D20190125T182937.html on *.html...
Checking 1 external link...
Ran on 1 file!
HTML-Proofer finished successfully.
```

## approach 2: selenium
* selenium https://www.seleniumhq.org/
haven't tried

## approach 3
for each test, make browser save image displayed on screen as png, compare against groundtruth; if it differs make test fail and save images generated, uploading it somewhere, then we check visually whether new result is ok, and update groundtruth images
* important: groundtruth images are saved in a different repo
* cons: may be too rigid tests / more work

## approach 4 (maybe simplest, in combination w approach 3 maybe)
log js console and check logs show what we expect
https://stackoverflow.com/questions/19298420/log-javascript-console-into-a-log-file-with-firefox

## [EDIT] approach 5 (workaround): generate 1 image containing all plots
this mitigates downsides of current approach which opens a ton of browser tabs, consumes lots of memory, and is harder to verify:
use https://github.com/brentp/nim-plotly/issues/43 to generate subplots in a single window, and save the image
in CI, that image can be uploaded somewhere and a human can quickly verify if it looks ok

