### PR TITLE
fix #40 by explicitly depending on websocket@#head

### DIFF
--- a/plotly.nimble
+++ b/plotly.nimble
@@ -6,7 +6,11 @@ description   = "plotting library for nim"
 license       = "MIT"
 
 
-requires "nim >= 0.18.0", "chroma", "websocket", "jsbind", "webview"
+requires "nim >= 0.18.0", "chroma", "jsbind", "webview"
+# get head to fix https://github.com/brentp/nim-plotly/issues/40
+# Remove once websocket has new version tag
+requires "https://github.com/niv/websocket.nim#head"
+
 srcDir = "src"
 
 skipDirs = @["tests"]


### PR DESCRIPTION
For some reason just using
```
requires "websocket#head"
```
does not seem to work on my machine.