### PR TITLE
Add more API tests (and actually run them)

### DIFF
--- a/plotly.nimble
+++ b/plotly.nimble
@@ -15,10 +15,12 @@ skipDirs = @["tests"]
 import ospaths,strutils
 
 task test, "run the tests":
+  exec "nim c -r tests/plotly/test_api.nim"
   exec "nim c --lineDir:on --debuginfo -r examples/all"
   exec "nim c --lineDir:on --debuginfo --threads:on -r examples/fig12_save_figure.nim"
 
 task travisTest, "run the tests on travis":
+  exec "nim c -r tests/plotly/test_api.nim"
   # define the `travis` flag to use our custom `xdg-open` based proc to open
   # firefox, which is non-blocking
   exec "nim c --lineDir:on -d:travis --debuginfo -r examples/all"

--- a/plotly.nimble
+++ b/plotly.nimble
@@ -6,7 +6,7 @@ description   = "plotting library for nim"
 license       = "MIT"
 
 
-requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "websocket  >= 0.3.5"
+requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "websocket#head"
 
 srcDir = "src"
 

--- a/src/plotly/api.nim
+++ b/src/plotly/api.nim
@@ -114,7 +114,7 @@ func `%`*(f: Font): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if f.size != 0:
     fields["size"] = % f.size
-  if not f.color.empty:
+  if not f.color.isEmpty:
     fields["color"] = % f.color
   if f.family.len > 0:
     fields["family"] = % f.family
@@ -144,7 +144,7 @@ func `%`*(a: Axis): JsonNode =
   if a.rangeslider != nil:
     fields["rangeslider"] = % a.rangeslider
 
-  if not a.gridColor.empty:
+  if not a.gridColor.isEmpty:
     fields["gridcolor"] = % a.gridColor
   if a.gridWidth != 0:
     fields["gridwidth"] = % a.gridWidth
@@ -155,9 +155,9 @@ func `%`*(l: Legend): JsonNode =
   var fields = initOrderedTable[string, JsonNode](4)
   if l.font != nil:
     fields["font"] = % l.font
-  if not l.backgroundColor.empty:
+  if not l.backgroundColor.isEmpty:
     fields["bgcolor"] = % l.backgroundColor
-  if not l.bordercolor.empty:
+  if not l.bordercolor.isEmpty:
     fields["bordercolor"] = % l.borderColor
   if l.borderwidth != 0:
     fields["borderwidth"] = % l.borderWidth
@@ -201,9 +201,9 @@ func `%`*(l: Layout): JsonNode =
     fields["hovermode"] = % l.hovermode
   if 0 < l.annotations.len:
     fields["annotations"] = % l.annotations
-  if not l.backgroundColor.empty:
+  if not l.backgroundColor.isEmpty:
     fields["plot_bgcolor"] = % l.backgroundColor
-  if not l.paperColor.empty:
+  if not l.paperColor.isEmpty:
     fields["paper_bgcolor"] = % l.paperColor
 
   result = JsonNode(kind: JObject, fields: fields)
@@ -222,7 +222,7 @@ func `%`*(b: ErrorBar): JsonNode =
   ## creates a JsonNode from an `ErrorBar` object depending on the object variant
   var fields = initOrderedTable[string, JsonNode](4)
   fields["visible"] = % b.visible
-  if not b.color.empty:
+  if not b.color.isEmpty:
     fields["color"] = % b.color.toHtmlHex
   if b.thickness > 0:
     fields["thickness"] = % b.thickness

--- a/src/plotly/color.nim
+++ b/src/plotly/color.nim
@@ -6,7 +6,7 @@ func empty*(): Color =
   ## returns completely black
   result = Color(r: 0, g: 0, b: 0, a: 0)
 
-func empty*(c: Color): bool =
+func isEmpty*(c: Color): bool =
   ## checks whether given color is black according to above
   # TODO: this is also black, but should never need black with alpha == 0
   result = c == empty()

--- a/src/plotly/errorbar.nim
+++ b/src/plotly/errorbar.nim
@@ -44,7 +44,7 @@ func newErrorBar*[T: SomeNumber](color: Color = empty(), thickness = 0.0,
                                  width = 0.0, visible = true): ErrorBar[T] =
   ## creates an `ErrorBar` object of type `ebkSqrt`
   result = ErrorBar[T](visible: visible, color: color, thickness: thickness,
-                         width: width, kind: ebkSqrt)
+                       width: width, kind: ebkSqrt)
 
 func newErrorBar*[T](err: seq[T], color: Color = empty(), thickness = 0.0,
                      width = 0.0, visible = true): ErrorBar[T] =

--- a/tests/plotly/test_api.nim
+++ b/tests/plotly/test_api.nim
@@ -1,10 +1,236 @@
 import ../../src/plotly
+import ../../src/plotly/color
+import chroma
 import unittest
 import json
 
-suite "Annotation Json tests":
-  test "make Json object":
+suite "Miscellaneous":
+  test "Color checks":
+    let c = empty()
+    check c.isEmpty
+
+suite "API serialization":
+  test "Color":
     let
+      c1 = % color(1.0)
+      c2 = % color(0.5, 0.5, 0.5)
+      c3 = % empty()
+    check c1 == % "#FFFFFF"
+    check c2 == % "#7F7F7F"
+    check c3 == % "#000000"
+
+
+  test "ErrorBar":
+    test "make ConstantSym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkConstantSym,
+                             value: 2.0)
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric" : true,
+                       "type": "constant",
+                       "value": 2.0
+                    }
+      let r = %eb
+      check r == expected
+    test "make ConstantSym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float](2.0) # fields not given won't be serialized
+        expected = %*{ "visible": true,
+                       "symmetric" : true,
+                       "type": "constant",
+                       "value": 2.0
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make PercentSym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkPercentSym,
+                             percent: 5.0)
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric" : true,
+                       "type": "percent",
+                       "value": 5.0
+                    }
+      let r = %eb
+      check r == expected
+    test "make PercentSym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float](2.0, percent = true) # fields not given won't be serialized
+        expected = %*{ "visible": true,
+                       "symmetric" : true,
+                       "type": "percent",
+                       "value": 2.0
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make ConstantAsym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkConstantAsym,
+                             valuePlus: 2.0,
+                             valueMinus: 1.0)
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric" : false,
+                       "type": "constant",
+                       "value": 2.0,
+                       "valueminus" : 1.0
+                    }
+      let r = %eb
+      check r == expected
+    test "make ConstantAsym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float]((m: 1.0, p: 2.0)) # fields not given won't be serialized
+        expected = %*{ "visible": true,
+                       "symmetric" : false,
+                       "type": "constant",
+                       "value": 2.0,
+                       "valueminus" : 1.0
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make PercentAsym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkPercentAsym,
+                             percentPlus: 2.0,
+                             percentMinus: 1.0)
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric" : false,
+                       "type": "percent",
+                       "value": 2.0,
+                       "valueminus" : 1.0
+                    }
+      let r = %eb
+      check r == expected
+    test "make ConstantAsym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float]((m: 1.0, p: 2.0), percent = true) # fields not given won't be serialized
+        expected = %*{ "visible": true,
+                       "symmetric" : false,
+                       "type": "percent",
+                       "value": 2.0,
+                       "valueminus" : 1.0
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make Sqrt ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkSqrt)
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "type": "sqrt",
+                    }
+      let r = %eb
+      check r == expected
+    test "make Sqrt ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float]() # TODO: this proc should really be renamed!
+        expected = %*{ "visible": true,
+                       "type": "sqrt",
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make ArraySym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkArraySym,
+                             errors: @[1.0, 2.0, 3.0])
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric": true,
+                       "type": "data",
+                       "array" : [1.0, 2.0, 3.0]
+                    }
+      let r = %eb
+      check r == expected
+    test "make ArraySym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float](@[1.0, 2.0, 3.0]) # TODO: this proc should really be renamed!
+        expected = %*{ "visible": true,
+                       "symmetric": true,
+                       "type": "data",
+                       "array": [1.0, 2.0, 3.0]
+                    }
+      let r = %eb
+      check r == expected
+
+    test "make ArrayAsym ErrorBar, manual":
+      let
+        eb = ErrorBar[float](visible: true,
+                             color: color(0.0),
+                             thickness: 1.0,
+                             width: 1.0,
+                             kind: ErrorBarKind.ebkArrayAsym,
+                             errorsPlus: @[1.0, 2.0, 3.0],
+                             errorsMinus: @[2.0, 3.0, 4.0])
+        expected = %*{ "visible": true,
+                       "color": "#00FFFF",
+                       "thickness": 1.0,
+                       "width" : 1.0,
+                       "symmetric": false,
+                       "type": "data",
+                       "array" : [1.0, 2.0, 3.0],
+                       "arrayminus" : [2.0, 3.0, 4.0]
+                    }
+      let r = %eb
+      check r == expected
+    test "make ArrayAsym ErrorBar, newErrorBar":
+      let
+        eb = newErrorBar[float]((m: @[2.0, 3.0, 4.0], p: @[1.0, 2.0, 3.0]))
+        expected = %*{ "visible": true,
+                       "symmetric": false,
+                       "type": "data",
+                       "array": [1.0, 2.0, 3.0],
+                       "arrayminus": [2.0, 3.0, 4.0]
+                    }
+      let r = %eb
+      check r == expected
+
+  test "Annotation":
+    test "make Json object":
+      let
         a = Annotation(x:1, xshift:10, y:2, yshift:20, text:"text")
         expected = %*{ "x": 1.0
                     , "xshift": 10.0
@@ -13,10 +239,10 @@ suite "Annotation Json tests":
                     , "text": "text"
                     , "showarrow": false
                     }
-    let r = %a
-    check r == expected
-  test "make Json object less parameters":
-    let 
+      let r = %a
+      check r == expected
+    test "make Json object less parameters":
+      let
         a = Annotation(x:1,y:2,text:"text")
         expected = %*{ "x": 1.0
                     , "xshift": 0.0
@@ -25,12 +251,12 @@ suite "Annotation Json tests":
                     , "text": "text"
                     , "showarrow": false
                     }
-    let r = %a
-    check r == expected
+      let r = %a
+      check r == expected
 
-suite "Layout Json tests":
-  test "Layout with Annotations":
-    let
+  test "Layout":
+    test "Layout with Annotations":
+      let
         a = Annotation(x:1, xshift:10, y:2, yshift:20, text:"text")
         layout = Layout(title: "title", width: 10, height: 10,
                         xaxis: Axis(title: "x"),
@@ -56,10 +282,10 @@ suite "Layout Json tests":
                                         }
                                       ]
                      }
-    let r = %layout
-    check r == expected
-  test "Layout without Annotations":
-    let
+      let r = %layout
+      check r == expected
+    test "Layout without Annotations":
+      let
         layout = Layout(title: "title", width: 10, height: 10,
                         xaxis: Axis(title: "x"),
                         yaxis: Axis(title: "y"),
@@ -75,5 +301,5 @@ suite "Layout Json tests":
                                 }
                      , "hovermode": "closest"
                      }
-    let r = %layout
-    check r == expected
+      let r = %layout
+      check r == expected

--- a/tests/plotly/test_api.nim
+++ b/tests/plotly/test_api.nim
@@ -19,6 +19,79 @@ suite "API serialization":
     check c2 == % "#7F7F7F"
     check c3 == % "#000000"
 
+  test "Marker":
+    test "make Markers, scalar size":
+      let
+        mk = Marker[float](size: @[1.0])
+        expected = %*{ "size": 1.0 }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, seq of sizes":
+      let
+        mk = Marker[float](size: @[1.0, 2.0, 3.0])
+        expected = %*{ "size": [1.0, 2.0, 3.0] }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, scalar color":
+      let
+        mk = Marker[float](size: @[1.0],
+                           color: @[color(0.5, 0.5, 0.5)])
+        expected = %*{ "size": 1.0,
+                       "color" : "#7F7F7F"
+                     }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, seq of colors":
+      let
+        mk = Marker[float](size: @[1.0],
+                           color: @[color(0.5, 0.5, 0.5), color(1.0), empty()])
+        expected = %*{ "size": 1.0,
+                       "color" : ["#7F7F7F", "#FFFFFF", "#000000"]
+                     }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, seq of color based on values; no color map":
+      let
+        mk = Marker[float](size: @[1.0],
+                           colorVals: @[0.25, 0.5, 0.75, 1.0])
+        expected = %*{ "size": 1.0,
+                       "color" : [0.25, 0.5, 0.75, 1.0],
+                       "colorscale" : "",
+                       "showscale" : true
+                     }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, seq of color based on values; w/ color map":
+      let
+        mk = Marker[float](size: @[1.0],
+                           colorVals: @[0.25, 0.5, 0.75, 1.0],
+                           colormap: ColorMap.Viridis
+        )
+        expected = %*{ "size": 1.0,
+                       "color" : [0.25, 0.5, 0.75, 1.0],
+                       "colorscale" : "Viridis",
+                       "showscale" : true
+                     }
+      let r = %mk
+      check r == expected
+
+    test "make Markers, color takes precedent over colorVals":
+      let
+        mk = Marker[float](size: @[1.0],
+                           color: @[color(0.5, 0.5, 0.5)],
+                           colorVals: @[0.25, 0.5, 0.75, 1.0],
+                           colormap: ColorMap.Viridis
+        )
+        expected = %*{ "size": 1.0,
+                       "color" : "#7F7F7F"
+                     }
+      let r = %mk
+      check r == expected
 
   test "ErrorBar":
     test "make ConstantSym ErrorBar, manual":
@@ -68,6 +141,7 @@ suite "API serialization":
                     }
       let r = %eb
       check r == expected
+
     test "make PercentSym ErrorBar, newErrorBar":
       let
         eb = newErrorBar[float](2.0, percent = true) # fields not given won't be serialized


### PR DESCRIPTION
I decided to finally start writing a few more API tests. So far I only added tests for color and `ErrorBar`, but I'll see to adding more.

While writing the tests I realized how confusing the `empty` proc that returns a bool is. Since it's not exported (the proc is, but color.nim is not), I simply renamed it to `isEmpty` without any deprecation.