### PR TITLE
swap values / frequency axis labels

### DIFF
--- a/examples/fig6_histogram.nim
+++ b/examples/fig6_histogram.nim
@@ -15,8 +15,8 @@ for i in 0..40:
 
 let
   layout = Layout(title: "histogram", width: 1200, height: 400,
-                  xaxis: Axis(title:"values"),
-                  yaxis: Axis(title: "frequency"),
+                  xaxis: Axis(title:"frequency"),
+                  yaxis: Axis(title: "values"),
                   autosize: false)
   p = Plot[int](layout: layout, traces: @[d])
 p.show()


### PR DESCRIPTION
This PR fixes the histogram example, where the y axis was labeled `frequency`, but it should be `values`, and vis versa.

This confusion may have arisen from the fact that the histogram is a row plot instead of a column plot.

Here is the result after the PR, with the proper labels.
<img width="1069" alt="pr" src="https://user-images.githubusercontent.com/6765756/63717055-037a7d80-c80d-11e9-876f-10ac86e37b64.png">

Here is the result before the PR, with the swapped labels.
<img width="1069" alt="head" src="https://user-images.githubusercontent.com/6765756/63717049-007f8d00-c80d-11e9-9a4b-4aa0fae5164d.png">
