### PR TITLE
push version v0.2.0, update dependency of websocket

### DIFF
--- a/plotly.nimble
+++ b/plotly.nimble
@@ -1,12 +1,12 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Brent Pedersen"
 description   = "plotting library for nim"
 license       = "MIT"
 
 
-requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "websocket#head"
+requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "websocket >= 0.4.1"
 
 srcDir = "src"
 


### PR DESCRIPTION
I was just in the "tagzzz all of the packagezzz!" mood, so I thought I'd push a new version of plotly too. I believe I can tag the master branch. I'll see once this is merged.

With the changes that happened since v0.1.0, I guess a new release was overdue anyways, haha. 

Note that I just selected the current websocket version, since I don't know anymore which version had the last breaking change (I know there was one). 