### PR TITLE
Fixes #57 by importing api, changing html template

### DIFF
--- a/examples/index_javascript.html
+++ b/examples/index_javascript.html
@@ -10,6 +10,6 @@
 <div id="lineplot"><!-- Line plot chart will be drawn inside this DIV --></div>
 <br>
 
-<script type="text/javascript" src="nimcache/fig8_js_interactive.js"></script>
+<script type="text/javascript" src="fig8_js_interactive.js"></script>
 </body>
 </html>

--- a/src/plotly/plotly_js.nim
+++ b/src/plotly/plotly_js.nim
@@ -2,6 +2,7 @@ import jsbind
 import jsffi
 import dom
 import plotly_types
+import api
 # defines some functions and types used for the JS target. In this case
 # we call the plotly.js functions directly.
 


### PR DESCRIPTION
As mentioned over in issue #57 by @brentp, we need to import `api` now in the `plotly_js.nim` file. I'm not quite sure why this wasn't required in the past? 

In any case, aside from that the default location of the example HTML template to be used with the interactive `fig8_*` example had to be changed, because the default location for the generated `js` file isn't the nimcache dir anymore. Fortunately that has been changed. 

@moukle once this is merged it should work again. Just make sure that after compiling the file via `nim js fig8...` you open the `index_javascript.html` file from within the `examples` directory (or otherwise change the `src="fig8_js_interactive.js"` line in your local example so that it matches your path to the file.