### PR TITLE
fix error message for websocket fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
         packages:
                 - libgtk-3-dev
                 - libwebkit2gtk-4.0-dev
+                - at-spi2-core
 
 install:
   - curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh

--- a/examples/fig20_custom_cmaps.nim
+++ b/examples/fig20_custom_cmaps.nim
@@ -7,7 +7,7 @@ import sequtils
 var data = newSeqWith(28, newSeq[float32](28))
 for x in 0 ..< 28:
   for y in 0 ..< 28:
-    data[x][y] = max(random(1.0), 0.3)
+    data[x][y] = max(rand(1.0), 0.3)
 
 let randomCustomMap = @[
 (r: 0.9719701409339905, g: 0.463617742061615, b: 0.4272273480892181),

--- a/plotly.nimble
+++ b/plotly.nimble
@@ -6,7 +6,7 @@ description   = "plotting library for nim"
 license       = "MIT"
 
 
-requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "websocket >= 0.4.1"
+requires "nim >= 0.18.0", "chroma", "jsbind", "webview", "ws"
 
 srcDir = "src"
 
@@ -24,7 +24,7 @@ task travisTest, "run the tests on travis":
   # define the `travis` flag to use our custom `xdg-open` based proc to open
   # firefox, which is non-blocking
   exec "nim c --lineDir:on -d:travis --debuginfo -r examples/all"
-  exec "nim c --lineDir:on -d:travis --debuginfo --threads:on -r examples/fig12_save_figure.nim"
+  exec "nim c --lineDir:on -d:travis -d:DEBUG --debuginfo --threads:on -r examples/fig12_save_figure.nim"
 
 task docs, "Builds documentation":
   mkDir("docs"/"plotly")

--- a/src/plotly/image_retrieve.nim
+++ b/src/plotly/image_retrieve.nim
@@ -78,7 +78,7 @@ proc cb(req: Request) {.async.} =
 
   if ws.isNil:
     echo "WS negotiation failed: ", error
-    await req.respond(Http400, "Websocket negotiation failed: " & error)
+    await req.respond(Http400, "Websocket negotiation failed: " & $error)
     req.client.close()
     return
   else:

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -1,5 +1,5 @@
 import strutils
-import os
+import os, osproc
 import json
 import sequtils
 
@@ -50,8 +50,8 @@ else:
       # patched version of Nim's `openDefaultBrowser` which always
       # returns immediately
       var u = quoteShell(file)
-      let cmd = "xdg-open " & u & " &"
-      discard execShellCmd(cmd)
+      let cmd = "xdg-open"
+      discard startProcess(command = cmd, args = [file], options = {poUsePath})
     else:
       # default normal browser
       openDefaultBrowser(file)

--- a/tests/plotly/test_api.nim
+++ b/tests/plotly/test_api.nim
@@ -452,7 +452,7 @@ suite "Sugar":
     var data = newSeqWith(28, newSeq[float](28))
     for x in 0 ..< 28:
       for y in 0 ..< 28:
-        data[x][y] = max(random(30.0), 0.1)
+        data[x][y] = max(rand(30.0), 0.1)
     let
       layout = Layout()
     block:


### PR DESCRIPTION
Seems like something changed in the either in the stdlib regarding printing of enums or `error` here simply wasn't an `enum` in the websocket library before?