### PR TITLE
fix: WSL check failing on mac

### DIFF
--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -29,7 +29,7 @@ template openBrowser(): untyped {.dirty.} =
   # default normal browser
   when defined(posix):
     # check if running under WSL, if so convert to full path
-    let release = posix_utils.uname().release
+    let release = uname().release
     if "microsoft" in release or "Microsoft" in release:
       let res = execCmdEx("wslpath -m " & file)
       openDefaultBrowser("file://" & res[0].strip)

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -2,7 +2,6 @@ import strutils
 import os, osproc
 import json
 import sequtils
-import posix_utils
 
 # we now import the plotly modules and export them so that
 # the user sees them as a single module
@@ -24,6 +23,9 @@ const hasThreadSupport* = compileOption("threads")
 when hasThreadSupport:
   import threadpool
   import plotly/image_retrieve
+
+when defined(posix):
+  import posix_utils
 
 template openBrowser(): untyped {.dirty.} =
   # default normal browser

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -2,6 +2,7 @@ import strutils
 import os, osproc
 import json
 import sequtils
+import posix_utils
 
 # we now import the plotly modules and export them so that
 # the user sees them as a single module
@@ -28,7 +29,8 @@ template openBrowser(): untyped {.dirty.} =
   # default normal browser
   when defined(posix):
     # check if running under WSL, if so convert to full path
-    if "Microsoft" in readFile("/proc/version"):
+    let release = posix_utils.uname().release
+    if "microsoft" in release or "Microsoft" in release:
       let res = execCmdEx("wslpath -m " & file)
       openDefaultBrowser("file://" & res[0].strip)
     else:


### PR DESCRIPTION
Problem
I had a couple of issues with the check for running under WSL
1. The `/proc/version` file does not exist on all Posixes, notably not on MacOS. This was causing the program to crash with an `OSError`
2. Windows release was lower case in my WSL version (running Debian under WSL2)

Fix
Using `uname()` from `posix_tools` should be more portable for other Posixes and will not crash if the file doesn't exist. Also added check for `windows ` and `Windows`!

I hope it's OK to create a PR without an issue first. Happy to create one if you prefer.