### PR TITLE
Continuation of #39 (resizing, temp files)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
 
 language: c
-dist: xenial
+dist: focal
 services:
   - xvfb
 

--- a/src/plotly.nim
+++ b/src/plotly.nim
@@ -1,8 +1,3 @@
-import strutils
-import json
-import chroma
-import sequtils
-
 # we now import the plotly modules and export them so that
 # the user sees them as a single module
 import plotly / [api, plotly_types, errorbar, plotly_sugar, plotly_subplots]

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -126,11 +126,12 @@ proc fillHtmlTemplate(htmlTemplate,
 
   let scriptTag = if autoResize: resizeScript()
                   else: staticScript()
+  let scriptFilled = scriptTag % [ "data", data_string,
+                                   "layout", slayout ]
+
   # now fill all values into the html template
-  result = htmlTemplate % [ "data", data_string,
-                            "layout", slayout,
-                            "title", title,
-                            "scriptTag", scriptTag,
+  result = htmlTemplate % [ "title", title,
+                            "scriptTag", scriptFilled,
                             "saveImage", imageInject]
 
 proc genPlotDirname(filename, outdir: string): string =

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -317,7 +317,8 @@ else:
            htmlPath = htmlPath,
            htmlTemplate = htmlTemplate,
            onlySave = true,
-           removeTempFile = removeTempFile)
+           removeTempFile = removeTempFile,
+           autoResize = autoResize)
 
   when not defined(js):
     proc show*(grid: Grid,
@@ -343,4 +344,5 @@ else:
       grid.toPlotJson.show(filename,
                            htmlPath = htmlPath,
                            htmlTemplate = htmlTemplate,
-                           removeTempFile = removeTempFile)
+                           removeTempFile = removeTempFile,
+                           autoResize = autoResize)

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -137,12 +137,14 @@ proc fillHtmlTemplate(htmlTemplate,
 proc genPlotDirname(filename, outdir: string): string =
   ## generates unique name for the given input file based on its name and
   ## the current time
-  let filename = if filename.len == 0: "nim_plotly" # default to give some sane human readable idea
+  const defaultName = "nim_plotly"
+  let filename = if filename.len == 0: defaultName # default to give some sane human readable idea
                  else: splitFile(filename)[1]
   let timeStr = format(now(), "yyyy-MM-dd'_'HH-mm-ss'.'fff")
-  let dir = outdir / filename & "_" & timeStr
+  let dir = outdir / defaultName
   createDir(dir)
-  result = dir / filename & ".html"
+  let outfile = filename & "_" & timeStr & ".html"
+  result = dir / outfile
 
 proc save*(p: SomePlot,
            htmlPath = "",

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -90,10 +90,11 @@ proc fillImageInjectTemplate(filetype, width, height: string): string =
                               width,
                               height]
 
-proc fillHtmlTemplate(html_template,
+proc fillHtmlTemplate(htmlTemplate,
                       data_string: string,
                       p: SomePlot,
-                      filename = ""): string =
+                      filename = "",
+                      autoResize = true): string =
   ## fills the HTML template with the correct strings and, if compiled with
   ## ``--threads:on``, inject the save image HTML code and fills that
   var
@@ -123,100 +124,220 @@ proc fillHtmlTemplate(html_template,
         let sheight = $p.layout{"height"}
       imageInject = fillImageInjectTemplate(filetype, swidth, sheight)
 
+  let scriptTag = if autoResize: resizeScript()
+                  else: staticScript()
   # now fill all values into the html template
-  result = html_template % ["data", data_string, "layout", slayout,
-                            "title", title, "saveImage", imageInject]
+  result = htmlTemplate % [ "data", data_string,
+                            "layout", slayout,
+                            "title", title,
+                            "scriptTag", scriptTag,
+                            "saveImage", imageInject]
 
-proc save*(p: SomePlot, path = "", html_template = defaultTmplString, filename = ""): string =
-  result = path
-  if result == "":
-    when defined(Windows):
-      result = getEnv("TEMP") / "x.html"
-    else:
-      result = "/tmp/x.html"
+proc genPlotDirname(filename, outdir: string): string =
+  ## generates unique name for the given input file based on its name and
+  ## the current time
+  let filename = if filename.len == 0: "nim_plotly" # default to give some sane human readable idea
+                 else: splitFile(filename)[1]
+  let timeStr = format(now(), "yyyy-MM-dd'_'HH-mm-ss'.'fff")
+  let dir = outdir / filename & "_" & timeStr
+  createDir(dir)
+  result = dir / filename & ".html"
+
+proc save*(p: SomePlot,
+           htmlPath = "",
+           htmlTemplate = defaultTmplString,
+           filename = "",
+           autoResize = true
+          ): string =
+  result = if htmlPath.len > 0: htmlPath
+           else: genPlotDirname(filename, getTempDir())
 
   when type(p) is Plot:
     # convert traces to data suitable for plotly and fill Html template
     let data_string = parseTraces(p.traces)
   else:
     let data_string = $p.traces
-  let html = html_template.fillHtmlTemplate(data_string, p, filename)
+  let html = htmlTemplate.fillHtmlTemplate(data_string, p, filename, autoResize)
 
-  var
-    f: File
-  if not open(f, result, fmWrite):
-    quit "could not open file for json"
-  f.write(html)
-  f.close()
+  writeFile(result, html)
 
 when not hasThreadSupport:
   # some violation of DRY for the sake of better error messages at
   # compile time
   proc show*(p: SomePlot,
              filename: string,
-             path = "",
-             html_template = defaultTmplString)
+             htmlPath = "",
+             htmlTemplate = defaultTmplString,
+             removeTempFile = false,
+             autoResize = true)
     {.error: "`filename` argument to `show` only supported if compiled " &
       "with --threads:on!".}
 
-  proc show*(p: SomePlot, path = "", html_template = defaultTmplString) =
-    ## creates the temporary Html file using `save`, and opens the user's
-    ## default browser
-    let tmpfile = p.save(path, html_template)
-
+  proc show*(p: SomePlot,
+             htmlPath = "",
+             htmlTemplate = defaultTmplString,
+             removeTempFile = false,
+             autoResize = true) =
+    ## Creates the temporary Html file in using `save`, and opens the user's
+    ## default browser.
+    ##
+    ## If `htmlPath` is given the file is stored in the given path and name.
+    ## Else a suitable name will be generated based on the current time.
+    ##
+    ## `htmlTemplate` allows to overwrite the default HTML template.
+    ##
+    ## If `removeTempFile` is true, the temporary file will be deleted after
+    ## a short while (not recommended).
+    ##
+    ## If `autoResize` is true, the shown plot will automatically resize according
+    ## to the browser window size. This overrides any possible custom sizes for
+    ## the plot. By default it is disabled for plots that should be saved.
+    let tmpfile = p.save(htmlPath = htmlPath,
+                         htmlTemplate = htmlTemplate,
+                         autoResize = autoResize)
     showPlot(tmpfile)
-    sleep(1000)
-    ## remove file after thread is finished
-    removeFile(tmpfile)
+    if removeTempFile:
+      sleep(2000)
+      ## remove file after thread is finished
+      removeFile(tmpfile)
 
-  proc saveImage*(p: SomePlot, filename: string)
+  proc saveImage*(p: SomePlot, filename: string,
+                  htmlPath = "",
+                  htmlTemplate = defaultTmplString,
+                  removeTempFile = false,
+                  autoResize = false)
     {.error: "`saveImage` only supported if compiled with --threads:on!".}
 
   when not defined(js):
-    proc show*(grid: Grid, filename: string)
+    proc show*(grid: Grid, filename: string,
+               htmlPath = "",
+               htmlTemplate = defaultTmplString,
+               removeTempFile = false,
+               autoResize = true)
       {.error: "`filename` argument to `show` only supported if compiled " &
         "with --threads:on!".}
 
-    proc show*(grid: Grid) =
-      ## display the `Grid` plot. Converts the `grid` to a call to
+    proc show*(grid: Grid,
+               htmlPath = "",
+               htmlTemplate = defaultTmplString,
+               removeTempFile = false,
+               autoResize = true) =
+      ## Displays the `Grid` plot. Converts the `grid` to a call to
       ## `combine` and calls `show` on it.
-      grid.toPlotJson.show()
+      ##
+      ## If `htmlPath` is given the file is stored in the given path and name.
+      ## Else a suitable name will be generated based on the current time.
+      ##
+      ## `htmlTemplate` allows to overwrite the default HTML template.
+      ##
+      ## If `removeTempFile` is true, the temporary file will be deleted after
+      ## a short while (not recommended).
+      ##
+      ## If `autoResize` is true, the shown plot will automatically resize according
+      ## to the browser window size. This overrides any possible custom sizes for
+      ## the plot. By default it is disabled for plots that should be saved.
+      grid.toPlotJson.show(htmlPath = htmlPath,
+                           htmlTemplate = defaultTmplString,
+                           removeTempFile = removeTempFile,
+                           autoResize = autoResize)
 else:
   # if compiled with --threads:on
   proc show*(p: SomePlot,
              filename = "",
-             path = "",
-             html_template = defaultTmplString,
-             onlySave: static bool = false) =
-    ## creates the temporary Html file using `save`, and opens the user's
+             htmlPath = "",
+             htmlTemplate = defaultTmplString,
+             onlySave: static bool = false,
+             removeTempFile = false,
+             autoResize = true) =
+    ## Creates the temporary Html file using `save`, and opens the user's
     ## default browser.
+    ##
     ## If `onlySave` is true, the plot is only saved and "not shown". However
     ## this only works on the `webview` target. And a webview window has to
     ## be opened, but will be closed automatically the moment the plot is saved.
+    ##
+    ## If `htmlPath` is given the file is stored in the given path and name.
+    ## Else a suitable name will be generated based on the current time.
+    ##
+    ## `htmlTemplate` allows to overwrite the default HTML template.
+    ##
+    ## If `removeTempFile` is true, the temporary file will be deleted after
+    ## a short while (not recommended).
+    ##
+    ## If `autoResize` is true, the shown plot will automatically resize according
+    ## to the browser window size. This overrides any possible custom sizes for
+    ## the plot. By default it is disabled for plots that should be saved.
     var thr: Thread[string]
     if filename.len > 0:
       # start a second thread with a webview server to capture the image
       thr.createThread(listenForImage, filename)
 
-    let tmpfile = p.save(path, html_template, filename)
+    let tmpfile = p.save(htmlPath = htmlPath,
+                         filename = filename,
+                         htmlTemplate = htmlTemplate,
+                         autoResize = autoResize)
     showPlotThreaded(tmpfile, thr, onlySave)
     if filename.len > 0:
       # wait for thread to join
       thr.joinThread
+    if removeTempFile:
+      sleep(2000)
+      removeFile(tmpfile)
 
-    removeFile(tmpfile)
-
-  proc saveImage*(p: SomePlot, filename: string) =
-    ## saves the image under the given filename
+  proc saveImage*(p: SomePlot, filename: string,
+                  htmlPath = "",
+                  htmlTemplate = defaultTmplString,
+                  removeTempFile = false,
+                  autoResize = false) =
+    ## Saves the image under the given filename
     ## supported filetypes:
+    ##
     ## - jpg, png, svg, webp
+    ##
     ## Note: only supported if compiled with --threads:on!
+    ##
     ## If the `webview` target is used, the plot is ``only`` saved and not
     ## shown (for long; webview closed after image saved correctly).
-    p.show(filename = filename, onlySave = true)
+    ##
+    ## If `htmlPath` is given the file is stored in the given path and name.
+    ## Else a suitable name will be generated based on the current time.
+    ##
+    ## `htmlTemplate` allows to overwrite the default HTML template.
+    ##
+    ## If `removeTempFile` is true, the temporary file will be deleted after
+    ## a short while (not recommended).
+    ##
+    ## If `autoResize` is true, the shown plot will automatically resize according
+    ## to the browser window size. This overrides any possible custom sizes for
+    ## the plot. By default it is disabled for plots that should be saved.
+    p.show(filename = filename,
+           htmlPath = htmlPath,
+           htmlTemplate = htmlTemplate,
+           onlySave = true,
+           removeTempFile = removeTempFile)
 
   when not defined(js):
-    proc show*(grid: Grid, filename = "") =
-      ## display the `Grid` plot. Converts the `grid` to a call to
+    proc show*(grid: Grid,
+               filename: string,
+               htmlPath = "",
+               htmlTemplate = defaultTmplString,
+               removeTempFile = false,
+               autoResize = true) =
+      ## Displays the `Grid` plot. Converts the `grid` to a call to
       ## `combine` and calls `show` on it.
-      grid.toPlotJson.show(filename)
+      ##
+      ## If `htmlPath` is given the file is stored in the given path and name.
+      ## Else a suitable name will be generated based on the current time.
+      ##
+      ## `htmlTemplate` allows to overwrite the default HTML template.
+      ##
+      ## If `removeTempFile` is true, the temporary file will be deleted after
+      ## a short while (not recommended).
+      ##
+      ## If `autoResize` is true, the shown plot will automatically resize according
+      ## to the browser window size. This overrides any possible custom sizes for
+      ## the plot. By default it is disabled for plots that should be saved.
+      grid.toPlotJson.show(filename,
+                           htmlPath = htmlPath,
+                           htmlTemplate = htmlTemplate,
+                           removeTempFile = removeTempFile)

--- a/src/plotly/plotly_display.nim
+++ b/src/plotly/plotly_display.nim
@@ -1,7 +1,4 @@
-import strutils
-import os, osproc
-import json
-import sequtils
+import std / [strutils, os, osproc, json, sequtils, times]
 
 # we now import the plotly modules and export them so that
 # the user sees them as a single module

--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -1,8 +1,21 @@
-proc removeComments(a: string): string=
-  ## removes lines starting with `#` (convenient; avoids having to use html comments when making edits)
-  for a in a.splitLines:
-    if a.strip.startsWith "#": continue
-    result.add a & "\n"
+template resizeScript(): untyped =
+  # TODO: this currently overrides size settings given in plots;
+  # need to expose whether to autoresize or not
+  # Note: this didn't seem to work: Plotly.Plots.resize('plot0');
+  """
+      runRelayout = function() {
+        var margin = 50; // if 0, would introduce scrolling
+        Plotly.relayout('plot0', {width: window.innerWidth - margin, height: window.innerHeight - margin } );
+      };
+      window.onresize = runRelayout;
+      # Consider: {responsive: true}
+      Plotly.newPlot('plot0', $data, $layout).then(runRelayout);
+"""
+
+template staticScript(): untyped =
+  ## the default script to get a static plot used if the user wishes to save a file as well
+  ## as view it
+  """Plotly.newPlot('plot0', $data, $layout)"""
 
 const defaultTmplString = """
 <!DOCTYPE html>
@@ -15,21 +28,12 @@ const defaultTmplString = """
   <body>
     <div id="plot0"></div>
     <script>
-        # TODO: this currently overrides size settings given in plots;
-        # need to expose whether to autoresize or not
-        # Note: this didn't seem to work: Plotly.Plots.resize('plot0');
-        runRelayout = function() {
-          var margin = 50; // if 0, would introduce scrolling
-          Plotly.relayout('plot0', {width: window.innerWidth - margin, height: window.innerHeight - margin } );
-        };
-        window.onresize = runRelayout;
-       # Consider: {responsive: true}
-       Plotly.newPlot('plot0', $data, $layout).then(runRelayout);
+      $scriptTag
     </script>
     $saveImage
   </body>
 </html>
-""".removeComments
+"""
 
 # type needs to be inserted!
 # either
@@ -55,4 +59,3 @@ const injectImageCode = """
         };
 </script>
 """
-

--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -2,13 +2,13 @@ template resizeScript(): untyped =
   # TODO: this currently overrides size settings given in plots;
   # need to expose whether to autoresize or not
   # Note: this didn't seem to work: Plotly.Plots.resize('plot0');
+  # Consider to add: `{responsive: true}`
   """
       runRelayout = function() {
         var margin = 50; // if 0, would introduce scrolling
         Plotly.relayout('plot0', {width: window.innerWidth - margin, height: window.innerHeight - margin } );
       };
       window.onresize = runRelayout;
-      # Consider: {responsive: true}
       Plotly.newPlot('plot0', $data, $layout).then(runRelayout);
 """
 

--- a/src/plotly/tmpl_html.nim
+++ b/src/plotly/tmpl_html.nim
@@ -1,20 +1,35 @@
+proc removeComments(a: string): string=
+  ## removes lines starting with `#` (convenient; avoids having to use html comments when making edits)
+  for a in a.splitLines:
+    if a.strip.startsWith "#": continue
+    result.add a & "\n"
+
 const defaultTmplString = """
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8" />
-		<title>$title</title>
-		 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-	</head>
-	<body>
-		<div id="plot0"></div>
-		<script>
-			Plotly.newPlot('plot0', $data, $layout)
-                </script>
-                $saveImage
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>$title</title>
+     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  </head>
+  <body>
+    <div id="plot0"></div>
+    <script>
+        # TODO: this currently overrides size settings given in plots;
+        # need to expose whether to autoresize or not
+        # Note: this didn't seem to work: Plotly.Plots.resize('plot0');
+        runRelayout = function() {
+          var margin = 50; // if 0, would introduce scrolling
+          Plotly.relayout('plot0', {width: window.innerWidth - margin, height: window.innerHeight - margin } );
+        };
+        window.onresize = runRelayout;
+       # Consider: {responsive: true}
+       Plotly.newPlot('plot0', $data, $layout).then(runRelayout);
+    </script>
+    $saveImage
+  </body>
 </html>
-"""
+""".removeComments
 
 # type needs to be inserted!
 # either
@@ -37,7 +52,7 @@ const injectImageCode = """
           // need to wait a short while to be sure the promise is fullfilled (I believe?!)
           connection.send("connected")
           setTimeout(function(){ connection.send(imageData); }, 100);
-};
+        };
 </script>
 """
 

--- a/tests/plotly/test_api.nim
+++ b/tests/plotly/test_api.nim
@@ -16,7 +16,7 @@ suite "Miscellaneous":
 suite "API serialization":
   test "Color":
     let
-      c1 = % color(1.0)
+      c1 = % color(1.0, 1.0, 1.0)
       c2 = % color(0.5, 0.5, 0.5)
       c3 = % empty()
     check c1 == % "#FFFFFF"
@@ -51,7 +51,7 @@ suite "API serialization":
     test "make Markers, seq of colors":
       let
         mk = Marker[float](size: @[1.0],
-                           color: @[color(0.5, 0.5, 0.5), color(1.0), empty()])
+                           color: @[color(0.5, 0.5, 0.5), color(1.0, 1.0, 1.0), empty()])
         expected = %*{ "size": 1.0,
                        "color" : ["#7F7F7F", "#FFFFFF", "#000000"]
                      }
@@ -101,7 +101,7 @@ suite "API serialization":
     test "make ConstantSym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkConstantSym,
@@ -130,7 +130,7 @@ suite "API serialization":
     test "make PercentSym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkPercentSym,
@@ -160,7 +160,7 @@ suite "API serialization":
     test "make ConstantAsym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkConstantAsym,
@@ -192,7 +192,7 @@ suite "API serialization":
     test "make PercentAsym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkPercentAsym,
@@ -224,7 +224,7 @@ suite "API serialization":
     test "make Sqrt ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkSqrt)
@@ -248,7 +248,7 @@ suite "API serialization":
     test "make ArraySym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkArraySym,
@@ -277,7 +277,7 @@ suite "API serialization":
     test "make ArrayAsym ErrorBar, manual":
       let
         eb = ErrorBar[float](visible: true,
-                             color: color(0.0),
+                             color: color(0.0, 1.0, 1.0),
                              thickness: 1.0,
                              width: 1.0,
                              kind: ErrorBarKind.ebkArrayAsym,


### PR DESCRIPTION
This is a rebase and continuation of #39. 

The main differences being:
- auto resizing of the plot is an argument to the different procedures. For `saveImage` by default it is false (to keep the sizes) and for `show` it is true
- make the names for some arguments clearer (in particular `path`) to hand a custom path for the generated HTML, which already allowed to overwrite the default `/tmp/x.html`
- we generate a directory based on the given filename (if none then we use "nim_plotly" as a default) & the current date (in millisecond accuracy)
- adds an option to remove the HTML files (by default false)
- and some small fixes for the tests 